### PR TITLE
Fixes a bug when base_version set

### DIFF
--- a/pulp_ansible/app/tasks/synchronizing.py
+++ b/pulp_ansible/app/tasks/synchronizing.py
@@ -186,8 +186,9 @@ def fetch_content(base_version):
     """
     content = set()
     if base_version:
-        for role in AnsibleRoleVersion.objects.filter(pk__in=base_version.content):
-            key = Key(name=role.name, namespace=role.namespace, version=role.version)
+        for role_version in AnsibleRoleVersion.objects.filter(pk__in=base_version.content):
+            key = Key(name=role_version.role.name, namespace=role_version.role.namespace,
+                      version=role_version.version)
             content.add(key)
     return content
 


### PR DESCRIPTION
The models refactor moved the attributes. This is only a problem on the
second sync because the first one has base_version=None.