### PR TITLE
Remove removed options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Create a repository ``foo``
 Create a new remote ``bar``
 -----------------------------
 
-``$ http POST :8000/pulp/api/v3/remotes/ansible/ name=bar download_policy='immediate' sync_mode='additive' url='https://galaxy.ansible.com/api/v1/roles/?namespace=elastic'``
+``$ http POST :8000/pulp/api/v3/remotes/ansible/ name=bar url='https://galaxy.ansible.com/api/v1/roles/?namespace=elastic'``
 
 .. code:: json
 


### PR DESCRIPTION
The sync_mode and download_policy options were removed from Remote so
the users should not be told to submit them.

https://pulp.plan.io/issues/3595
closes #3595