### PR TITLE
Make pytest tell why tests skip

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -28,7 +28,7 @@ show_logs_and_return_non_zero() {
     cat ~/'reserved_worker-1.log'
     return "${rc}"
 }
-pytest -v --color=yes --pyargs pulp_ansible.tests.functional || show_logs_and_return_non_zero
+pytest -v -r a --color=yes --pyargs pulp_ansible.tests.functional || show_logs_and_return_non_zero
 
 # Travis' scripts use unbound variables. This is problematic, because the
 # changes made to this script's environment appear to persist when Travis'


### PR DESCRIPTION
When a test skips, pytest doesn't print information about why that test
skipped. Make pytest print skip messages. For example, if a test
contains this line:

    self.skipTest('https://pulp.plan.io/issues/1')

...then pytest should print `https://pulp.plan.io/issues/1` in its
report.