### PR TITLE
Change how test requirements are listed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,19 @@ setup(
     author_email='pulp-dev@redhat.com',
     url='https://github.com/pulp/pulp_ansible',
     install_requires=requirements,
+    extras_require={
+        'test': [
+            'coverage',
+            'coveralls',
+            'flake8',
+            'flake8-docstrings',
+            'flake8-quotes',
+            'flake8-tuple',
+            'mock',
+            'pulp-smash',
+            'pytest',
+        ]
+    },
     include_package_data=True,
     packages=['pulp_ansible', 'pulp_ansible.app'],
     classifiers=(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,2 @@
-coveralls
-coverage
-flake8
-flake8-docstrings
-flake8-tuple
-flake8-quotes
-mock
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
-pytest
+.[test]


### PR DESCRIPTION
The pulp-ansible plugin distributes unit and functional tests for its
code alongside the code itself. Given this, the plugin should tell users
what they need to install in order to run those tests.

Define a new optional dependency called "test." It can be used like so:

    pip install pulp-ansible[test]

This install not only pulp-ansible and its hard dependencies, but also
everything needed for running unit tests and functional tests. The
tooling for actually *running* these tests once the dependences are
installed is not so great. This can be improved with some hard thought
and elbow grease.

See:
https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies