### PR TITLE
Add policy to remote tests

### DIFF
--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from django.db import models
 
-from pulpcore.plugin.models import Content, ContentArtifact, Remote
+from pulpcore.plugin.models import Content, Remote
 
 
 log = getLogger(__name__)
@@ -34,30 +34,6 @@ class AnsibleRoleVersion(Content):
 
     version = models.CharField(max_length=128)
     role = models.ForeignKey(AnsibleRole, on_delete=models.PROTECT, related_name='versions')
-
-    @property
-    def artifact(self):
-        """
-        Return the artifact id (there is only one for this content type).
-        """
-        return self._artifacts.get().pk
-
-    @artifact.setter
-    def artifact(self, artifact):
-        """
-        Set the artifact for this Ansible Role version.
-        """
-        if self.pk:
-            ca = ContentArtifact(
-                artifact=artifact,
-                content=self,
-                relative_path="{namespace}/{name}/{version}.tar.gz".format(
-                    namespace=self.role.namespace,
-                    name=self.role.name,
-                    version=self.version
-                )
-            )
-            ca.save()
 
     @property
     def relative_path(self):

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -1,13 +1,17 @@
 from rest_framework import serializers
 
-from pulpcore.plugin.serializers import ContentSerializer, IdentityField, NestedIdentityField, \
-    RelatedField, RemoteSerializer
-from pulpcore.plugin.models import Artifact
+from pulpcore.plugin.serializers import (
+    IdentityField,
+    NestedIdentityField,
+    NoArtifactContentSerializer,
+    RemoteSerializer,
+    SingleArtifactContentSerializer,
+)
 
 from .models import AnsibleRemote, AnsibleRole, AnsibleRoleVersion
 
 
-class AnsibleRoleSerializer(ContentSerializer):
+class AnsibleRoleSerializer(NoArtifactContentSerializer):
     """
     A serializer for Ansible Roles.
     """
@@ -30,7 +34,7 @@ class AnsibleRoleSerializer(ContentSerializer):
         model = AnsibleRole
 
 
-class AnsibleRoleVersionSerializer(ContentSerializer):
+class AnsibleRoleVersionSerializer(SingleArtifactContentSerializer):
     """
     A serializer for Ansible Role versions.
     """
@@ -40,16 +44,10 @@ class AnsibleRoleVersionSerializer(ContentSerializer):
         parent_lookup_kwargs={'role_pk': 'role__pk'},
     )
 
-    artifact = RelatedField(
-        view_name='artifacts-detail',
-        help_text="Artifact file representing the physical content",
-        queryset=Artifact.objects.all()
-    )
-
     version = serializers.CharField()
 
     class Meta:
-        fields = ('_href', 'version', 'artifact')
+        fields = SingleArtifactContentSerializer.Meta.fields + ('version',)
         model = AnsibleRoleVersion
 
 

--- a/pulp_ansible/tests/functional/api/test_crud_remotes.py
+++ b/pulp_ansible/tests/functional/api/test_crud_remotes.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 
-from pulp_ansible.tests.functional.constants import ANSIBLE_REMOTE_PATH
+from pulp_ansible.tests.functional.constants import ANSIBLE_REMOTE_PATH, DOWNLOAD_POLICIES
 from pulp_ansible.tests.functional.utils import skip_if, gen_ansible_remote
 from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
@@ -126,6 +126,7 @@ def _gen_verbose_remote():
     attrs.update({
         'password': utils.uuid4(),
         'username': utils.uuid4(),
+        'policy': choice(DOWNLOAD_POLICIES),
         'validate': choice((False, True)),
     })
     return attrs

--- a/pulp_ansible/tests/functional/constants.py
+++ b/pulp_ansible/tests/functional/constants.py
@@ -7,6 +7,9 @@ from pulp_smash.pulp3.constants import (  # noqa:F401
     CONTENT_PATH
 )
 
+DOWNLOAD_POLICIES = ['cache_only', 'immediate', 'on_demand']
+"""Allowed download policies for this plugin."""
+
 ANSIBLE_ROLE_CONTENT_NAME = 'pulp_ansible.ansible-role-version'
 
 ANSIBLE_ROLE_CONTENT_PATH = urljoin(CONTENT_PATH, 'ansible/roles/')

--- a/pulp_ansible/tests/functional/utils.py
+++ b/pulp_ansible/tests/functional/utils.py
@@ -67,7 +67,7 @@ def gen_ansible_content_attrs(artifact):
     :returns: A semi-random dict for use in creating a content unit.
     """
     # FIXME: add content specific metadata here
-    return {'artifact': artifact['_href']}
+    return {'_artifact': artifact['_href']}
 
 
 def populate_pulp(cfg, url=ANSIBLE_FIXTURE_URL):


### PR DESCRIPTION
Update _gen_verbose_remote to add download policy field. Add constant
DOWNLOAD_POLICIES.

re #4182
https://pulp.plan.io/issues/4182