### PR TITLE
Version bump to 0.1.0rc4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-ansible',
-    version='0.1.0rc2',
+    version='0.1.0rc4',
     description='Pulp plugin to manage Ansible content, e.g. roles',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
The update from 0.1.0rc2 -> 0.1.0rc3 happened directly from the 0.1.0rc2
tag so master was left with rc2 even with rc3 being available on PyPI.
This sets up master to be correct when the rc4 release does come out.

[noissue]