### PR TITLE
Fixing the order of publications endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,7 +190,7 @@ Add content to repository ``foo``
 Create a Publication
 -------------------------------------------------
 
-``$ http POST :8000/pulp/api/v3/ansible/publications/ repository=$REPO_HREF``
+``$ http POST :8000/pulp/api/v3/publications/ansible/ repository=$REPO_HREF``
 
 .. code:: json
 

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -127,7 +127,7 @@ class AnsiblePublicationsViewSet(NamedModelViewSet,
     ViewSet for Ansible Publications.
     """
 
-    endpoint_name = 'ansible/publications'
+    endpoint_name = 'publications/ansible'
     queryset = Publication.objects.all()
     serializer_class = RepositoryPublishURLSerializer
 


### PR DESCRIPTION
Master detail routes end with the namespace (eg /remotes/ansible,
/publishers/file, etc) so changing to be more consistent.

[noissue]