### PR TITLE
Version bump rc5 and declare compat w/ core's rc2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore-plugin',
+    'pulpcore-plugin~=0.1rc2',
 ]
 
 with open('README.rst') as f:
@@ -11,7 +11,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-ansible',
-    version='0.1.0rc4',
+    version='0.1.0rc5',
     description='Pulp plugin to manage Ansible content, e.g. roles',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
This version bumps to rc5 and declares compatability w/ core's rc2
release.

[noissue]