### PR TITLE
Set version to .dev for the master branch

### DIFF
--- a/.travis/publish_client_gem.sh
+++ b/.travis/publish_client_gem.sh
@@ -14,7 +14,7 @@ if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}
 else
   export EPOCH="$(date +%s)"
-  export VERSION=${REPORTED_VERSION}.dev.${EPOCH}
+  export VERSION=${REPORTED_VERSION}.${EPOCH}
 fi
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/pulp_ansible_client/versions/$VERSION)

--- a/pulp_ansible/__init__.py
+++ b/pulp_ansible/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.0b1'
+__version__ = '0.2.0b1.dev'
 
 default_app_config = 'pulp_ansible.app.PulpAnsiblePluginAppConfig'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-ansible',
-    version='0.2.0b1',
+    version='0.2.0b1.dev',
     description='Pulp plugin to manage Ansible content, e.g. roles',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
A correct version would be shown for installations from the master branch.
Bindings will be generated with a proper version as well.

re #4936
https://pulp.plan.io/issues/4936