### PR TITLE
Sync now always creates a RepositoryVersion

### DIFF
--- a/CHANGES/4920.bugfix
+++ b/CHANGES/4920.bugfix
@@ -1,0 +1,1 @@
+Collection sync now creates a new RepositoryVersion even if no new Collection content was added.


### PR DESCRIPTION
This change ensures there is always a repository version generated for
every sync, even if no content changed.

Prior to this change a re-sync that received no new Collection content
would not create a new repository verison. This deviates from other
plugin behaviors, and is also not desirable based on feedback.

https://pulp.plan.io/issues/4920
closes #4920