### PR TITLE
Fix mazer log errors about 'ansible_collections'

### DIFF
--- a/CHANGES/4999.bugfix
+++ b/CHANGES/4999.bugfix
@@ -1,0 +1,1 @@
+Collection sync no longer logs errors about a missing directory named 'ansible_collections'

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -52,6 +52,10 @@ def sync(remote_pk, repository_pk):
 
     with RepositoryVersion.create(repository) as new_version:
         with tempfile.TemporaryDirectory() as temp_ansible_path:
+
+            # workaround: mazer logs errors without this dir  https://pulp.plan.io/issues/4999
+            os.mkdir(temp_ansible_path + os.sep + 'ansible_collections')
+
             galaxy_context = GalaxyContext(
                 collections_path=temp_ansible_path,
                 server={


### PR DESCRIPTION
This fix gratuitously creates the 'ansible_collections' directory to
work around the error. I've filed an issue against Mazer and once fixed,
this workaround can be removed.

https://pulp.plan.io/issues/4999
closes #4999