### PR TITLE
Cause second sync content to associate correctly

### DIFF
--- a/CHANGES/4997.bugfix
+++ b/CHANGES/4997.bugfix
@@ -1,0 +1,1 @@
+Content present in a second sync now associates correctly with the newly created Repository Version.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -103,7 +103,7 @@ def sync(remote_pk, repository_pk):
                                 relative_path=collection.relative_path,
                             )
 
-                            collections_pks.append(collection)
+                        collections_pks.append(collection)
 
         collections = Collection.objects.filter(pk__in=collections_pks)
         new_version.add_content(collections)


### PR DESCRIPTION
The content associate only occured when the sync created the content
unit. When that content unit is associated with another repository the
sync doesn't associate the content correctly.

This associates content regardless of if this sync created it or it
already existed.

https://pulp.plan.io/issues/4997
closes #4997