### PR TITLE
Collection sync bugfix and progress reporting

### DIFF
--- a/CHANGES/4997.bugfix
+++ b/CHANGES/4997.bugfix
@@ -1,0 +1,1 @@
+Content present in a second sync now associates correctly with the newly created Repository Version.

--- a/CHANGES/5023.feature
+++ b/CHANGES/5023.feature
@@ -1,0 +1,1 @@
+Collection sync now provides basic progress reporting.


### PR DESCRIPTION
Previously the sync had no progress reports. Some users want progress
reporting even for fast tasks, e.g. Katello. This gives some basic
progress reporting.

https://pulp.plan.io/issues/5023
closes #5023

Cause second sync content to associate correctly

The content associate only occured when the sync created the content
unit. When that content unit is associated with another repository the
sync doesn't associate the content correctly.

This associates content regardless of if this sync created it or it
already existed.

https://pulp.plan.io/issues/4997
closes #4997