### PR TITLE
Add sha details to Collection list and detail APIs

### DIFF
--- a/CHANGES/4827.feature
+++ b/CHANGES/4827.feature
@@ -1,0 +1,1 @@
+Adds Artifact sha details to the Collection list and detail APIs.

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from rest_framework import serializers
 
 from pulpcore.plugin.serializers import (
+    ContentChecksumSerializer,
     RemoteSerializer,
     SingleArtifactContentSerializer,
     RepositoryVersionDistributionSerializer,
@@ -104,7 +105,7 @@ class AnsibleDistributionSerializer(RepositoryVersionDistributionSerializer):
         model = AnsibleDistribution
 
 
-class CollectionSerializer(SingleArtifactContentSerializer):
+class CollectionSerializer(SingleArtifactContentSerializer, ContentChecksumSerializer):
     """
     A serializer for Ansible Collection.
     """
@@ -114,6 +115,7 @@ class CollectionSerializer(SingleArtifactContentSerializer):
     version = serializers.CharField()
 
     class Meta:
-        fields = tuple(set(SingleArtifactContentSerializer.Meta.fields) - {'_relative_path'}) + (
-            'version', 'name', 'namespace')
+        fields = tuple(
+            set(SingleArtifactContentSerializer.Meta.fields) - {'_relative_path'}
+        ) + ContentChecksumSerializer.Meta.fields + ('version', 'name', 'namespace')
         model = Collection

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -85,7 +85,7 @@ class CollectionViewSet(ContentViewSet):
     """
 
     endpoint_name = 'collections'
-    queryset = Collection.objects.all()
+    queryset = Collection.objects.prefetch_related("_artifacts")
     serializer_class = CollectionSerializer
     filterset_class = CollectionFilter
 


### PR DESCRIPTION
The list and detail Collection APIs now include various sha details of
the associated Artifact. For example sha256, md5, etc. This avoids some
clients, e.g. Katello from making additional calls for the sha data
while users who want less data serialized over the interface can limit
the fields.

https://pulp.plan.io/issues/5018
closes #5018