### PR TITLE
Add 'latest' boolean for Collection filtering

### DIFF
--- a/CHANGES/5076.feature
+++ b/CHANGES/5076.feature
@@ -1,0 +1,2 @@
+Collection filtering now supports the 'latest' boolean. When True, only the most recent version of
+each ``namespace`` and ``name`` combination is included in filter results.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,6 @@ flake8-docstrings
 flake8-tuple
 flake8-quotes
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
+# pin pydocstyle until https://gitlab.com/pycqa/flake8-docstrings/issues/36 is resolved
+pydocstyle<4
 pytest


### PR DESCRIPTION
When 'latest' is True, only include a  Collection if it is the newest
version of <namespace, name>.

https://pulp.plan.io/issues/5076
closes #5076