### PR TITLE
Add 'packaging' dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     'mazer',
+    'packaging',
     'pulpcore-plugin~=0.1rc2',
 ]
 


### PR DESCRIPTION
Add 'packaging' dep required by
ca36e63b033a1371ee02797cd7a854093330b5b0

Haven't been able to test this yet, so YMMV.

For
```
Successfully installed pulp-ansible
[debug]: Waiting for port tcp://postgres:5432
[debug]: Waiting for port tcp://redis:6379
Traceback (most recent call last):
  File "/venv/bin/django-admin", line 10, in <module>
    sys.exit(execute_from_command_line())
  File "/venv/lib64/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/venv/lib64/python3.6/site-packages/django/core/management/__init__.py", line 357, in execute
    django.setup()
  File "/venv/lib64/python3.6/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/venv/lib64/python3.6/site-packages/django/apps/registry.py", line 122, in populate
    app_config.ready()
  File "/venv/lib64/python3.6/site-packages/pulpcore/app/apps.py", line 74, in ready
    self.import_viewsets()
  File "/venv/lib64/python3.6/site-packages/pulpcore/app/apps.py", line 107, in import_viewsets
    self.viewsets_module = import_module(viewsets_module_name)
  File "/usr/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/code/pulp-ansible/pulp_ansible/app/viewsets.py", line 3, in <module>
    from packaging.version import parse
ModuleNotFoundError: No module named 'packaging'
make: *** [Makefile:42: docker/run-migrations] Error 1

```