### PR TITLE
Problem: mariadb testing is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ env:
   matrix:
     - DB=postgres TEST=pulp
     - DB=postgres TEST=docs
-    - DB=mariadb TEST=pulp
+
     - DB=postgres TEST=bindings
 
 matrix:
   exclude:
-    - python: '3.6'
-      env: DB=mariadb TEST=pulp
+
     - python: '3.7'
       env: DB=postgres TEST=bindings
     - python: '3.6'
@@ -25,7 +24,7 @@ matrix:
 services:
     - postgresql
     - redis-server
-    - mariadb
+    
 addons:
   apt:
     packages:
@@ -33,7 +32,7 @@ addons:
       - jq
   # postgres versions provided by el7 RHSCL (lowest supportable version)
   postgresql: '9.6'
-  mariadb: '10.3'
+  
 before_install: .travis/before_install.sh
 install: .travis/install.sh
 before_script: .travis/before_script.sh

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -34,6 +34,9 @@ pip install -r test_requirements.txt
 # Lint code.
 flake8 --config flake8.cfg || exit 1
 
+# check the code style with black
+black --check --diff . || exit 1
+
 cd ..
 git clone https://github.com/pulp/ansible-pulp.git
 if [ -n "$PULP_ROLES_PR_NUMBER" ]; then

--- a/.travis/validate_commit_message.py
+++ b/.travis/validate_commit_message.py
@@ -10,22 +10,24 @@ import requests
 import subprocess
 import sys
 
-KEYWORDS = ['fixes', 'closes', 're', 'ref']
-NO_ISSUE = '[noissue]'
-STATUSES = ['NEW', 'ASSIGNED', 'POST']
+KEYWORDS = ["fixes", "closes", "re", "ref"]
+NO_ISSUE = "[noissue]"
+STATUSES = ["NEW", "ASSIGNED", "POST"]
 
 sha = sys.argv[1]
-message = subprocess.check_output(['git', 'log', '--format=%B', '-n 1', sha]).decode('utf-8')
+message = subprocess.check_output(["git", "log", "--format=%B", "-n 1", sha]).decode("utf-8")
 
 
 def __check_status(issue):
-    response = requests.get('https://pulp.plan.io/issues/{}.json'.format(issue))
+    response = requests.get("https://pulp.plan.io/issues/{}.json".format(issue))
     response.raise_for_status()
     bug_json = response.json()
-    status = bug_json['issue']['status']['name']
+    status = bug_json["issue"]["status"]["name"]
     if status not in STATUSES:
-        sys.exit("Error: issue #{issue} has invalid status of {status}. Status must be one of "
-                 "{statuses}.".format(issue=issue, status=status, statuses=", ".join(STATUSES)))
+        sys.exit(
+            "Error: issue #{issue} has invalid status of {status}. Status must be one of "
+            "{statuses}.".format(issue=issue, status=status, statuses=", ".join(STATUSES))
+        )
 
 
 print("Checking commit message for {sha}.".format(sha=sha[0:7]))
@@ -34,7 +36,7 @@ print("Checking commit message for {sha}.".format(sha=sha[0:7]))
 if NO_ISSUE in message:
     print("Commit {sha} has no issue attached. Skipping issue check".format(sha=sha[0:7]))
 else:
-    regex = r'(?:{keywords})[\s:]+#(\d+)'.format(keywords=('|').join(KEYWORDS))
+    regex = r"(?:{keywords})[\s:]+#(\d+)".format(keywords=("|").join(KEYWORDS))
     pattern = re.compile(regex)
 
     issues = pattern.findall(message)
@@ -43,7 +45,9 @@ else:
         for issue in pattern.findall(message):
             __check_status(issue)
     else:
-        sys.exit("Error: no attached issues found for {sha}. If this was intentional, add "
-                 " '{tag}' to the commit message.".format(sha=sha[0:7], tag=NO_ISSUE))
+        sys.exit(
+            "Error: no attached issues found for {sha}. If this was intentional, add "
+            " '{tag}' to the commit message.".format(sha=sha[0:7], tag=NO_ISSUE)
+        )
 
 print("Commit message for {sha} passed.".format(sha=sha[0:7]))

--- a/template_config.yml
+++ b/template_config.yml
@@ -1,0 +1,24 @@
+# This config represents the latest values used when running the template.
+
+exclude_black: false
+exclude_check_commit_message: false
+exclude_coverage: true
+exclude_deploy_client_to_pypi: false
+exclude_deploy_client_to_rubygems: false
+exclude_deploy_daily_client_to_pypi: false
+exclude_deploy_daily_client_to_rubygems: false
+exclude_deploy_to_pypi: false
+exclude_docs_test: false
+exclude_mariadb_test: true
+exclude_pydocstyle: false
+exclude_test_bindings: false
+plugin_camel: PulpAnsible
+plugin_camel_short: Ansible
+plugin_caps: PULP_ANSIBLE
+plugin_caps_short: ANSIBLE
+plugin_dash: pulp-ansible
+plugin_dash_short: ansible
+plugin_name: ansible
+plugin_snake: pulp_ansible
+plugin_snake_short: ansible
+pypi_username: pulp


### PR DESCRIPTION
Solution: remove mariadb testing from Travis pipeline

This patch adds a new template_config.yml file which is used by the plugin-template when
generating the Travis pipeline. The mariadb testing is disabled in template_config.yml.

This patch includes the latest changes generated by running plugin-template --travis
command.

[noissue]