### PR TITLE
Add full-text search to Collection filterset

### DIFF
--- a/CHANGES/5075.feature
+++ b/CHANGES/5075.feature
@@ -1,0 +1,2 @@
+Fulltext Collection search is available with the ``q`` filter argument. A migration creates
+databases indexes to speed up the search.

--- a/pulp_ansible/app/migrations/0004_add_fulltext_search_indexes.py
+++ b/pulp_ansible/app/migrations/0004_add_fulltext_search_indexes.py
@@ -1,0 +1,95 @@
+from django.contrib.postgres import search as psql_search
+from django.db import migrations
+
+
+# This query generates full text search index based
+# the following data ranked from A to D:
+#   - Namespace name (weight A)
+#   - Collection name (weight A)
+#   - Collection tags (weight B)
+#   - Collection content names (weight C)
+#   - Collection description (weight D)
+TS_VECTOR_SELECT = '''
+    setweight(to_tsvector(coalesce(namespace,'')), 'A')
+    || setweight(to_tsvector(coalesce(name, '')), 'A')
+    || (
+      SELECT
+        setweight(to_tsvector(
+          coalesce(string_agg("ansible_tag"."name", ' '), '')
+        ), 'B')
+      FROM
+        "ansible_tag" INNER JOIN "ansible_collectionversion_tags" ON ("ansible_tag"."_id" = "ansible_collectionversion_tags"."tag_id")
+    )
+    || (
+      SELECT
+        setweight(to_tsvector(
+          coalesce(string_agg(cvc ->> 'name', ' '), '')
+        ), 'C')
+      FROM jsonb_array_elements(cv.contents) AS cvc
+    )
+    || setweight(to_tsvector(coalesce(description, '')), 'D')
+'''
+
+# Generates search vector for existing CollectionVersion objects in the database.
+POPULATE_COLLECTIONS_TS_VECTOR = f'''
+UPDATE ansible_collectionversion AS c
+SET search_vector = (
+    SELECT {TS_VECTOR_SELECT}
+    FROM ansible_collectionversion cv
+)
+'''
+
+
+# Creates a database function and a trigger to update collection search
+# vector field when a collection reference to a newer version is updated.
+#
+# Since it's not possible to insert a collection version before a collection, a latest_version_id
+# always gets updated as a separated query after collectionversion is inserted. Thus only `ON
+# UPDATE` trigger is required.
+CREATE_COLLECTIONS_TS_VECTOR_TRIGGER = f'''
+CREATE OR REPLACE FUNCTION update_collection_ts_vector()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.search_vector := (
+        SELECT {TS_VECTOR_SELECT}
+        FROM ansible_collectionversion cv
+        WHERE cv.content_ptr_id = NEW.content_ptr_id
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER update_ts_vector
+    BEFORE UPDATE
+    ON ansible_collectionversion
+    FOR EACH ROW
+EXECUTE PROCEDURE update_collection_ts_vector();
+'''
+
+DROP_COLLECTIONS_TS_VECTOR_TRIGGER = '''
+DROP TRIGGER IF EXISTS update_ts_vector ON ansible_collectionversion;
+DROP FUNCTION IF EXISTS update_collection_ts_vector();
+'''
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ansible', '0003_add_tags_and_collectionversion_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='collectionversion',
+            name='search_vector',
+            field=psql_search.SearchVectorField(default=''),
+        ),
+        migrations.RunSQL(
+            sql=POPULATE_COLLECTIONS_TS_VECTOR,
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            sql=CREATE_COLLECTIONS_TS_VECTOR_TRIGGER,
+            reverse_sql=DROP_COLLECTIONS_TS_VECTOR_TRIGGER,
+        )
+    ]

--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -2,6 +2,7 @@ from logging import getLogger
 
 from django.db import models
 from django.contrib.postgres import fields as psql_fields
+from django.contrib.postgres import search as psql_search
 
 from pulpcore.plugin.models import Content, Model, Remote, RepositoryVersionDistribution
 
@@ -56,7 +57,7 @@ class Tag(Model):
 
 class CollectionVersion(Content):
     """
-    A content type representing a Collection.
+    A content type representing a CollectionVersion.
 
     This model is primarily designed to adhere to the data format for Collection content. That spec
     is here: https://docs.ansible.com/ansible/devel/dev_guide/collections_galaxy_meta.html
@@ -87,6 +88,7 @@ class CollectionVersion(Content):
 
     TYPE = "collection_version"
 
+    # Data Fields
     authors = psql_fields.ArrayField(models.CharField(max_length=64), default=list, editable=False)
     contents = psql_fields.JSONField(default=list, editable=False)
     dependencies = psql_fields.JSONField(default=dict, editable=False)
@@ -101,10 +103,14 @@ class CollectionVersion(Content):
     repository = models.URLField(default="", blank=True, max_length=128, editable=False)
     version = models.CharField(max_length=32, editable=False)
 
+    # Foreign Key Fields
     collection = models.ForeignKey(
         Collection, on_delete=models.CASCADE, related_name="versions", editable=False
     )
     tags = models.ManyToManyField(Tag, editable=False)
+
+    # Search Fields
+    search_vector = psql_search.SearchVectorField(default="")
 
     @property
     def relative_path(self):

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -152,8 +152,6 @@ def import_collection(artifact_pk):
             collection, created = Collection.objects.get_or_create(
                 namespace=collection_info["namespace"], name=collection_info["name"]
             )
-            if created:
-                CreatedResource.objects.create(content_object=collection)
 
             tags = collection_info.pop("tags")
 


### PR DESCRIPTION
With this the user can submit their full-text querystring as the 'q'
parameter. The results are rank sorted. It provides a weighted result
with the following weights:

- Namespace name (weight A)
- Collection name (weight A)
- Collection tags (weight B)
- Collection content names (weight C)
- Collection description (weight D)

https://pulp.plan.io/issues/5075
closes #5075