### PR TITLE
Modified vars section in pulp_ansible.yml

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,10 @@ Create your pulp_ansible.yml playbook to use with the installer:
    ---
    - hosts: all
      vars:
-       pulp_secret_key: secret
+       pulp_settings:
+         secret_key: secret
+         ansible_api_hostname: 'http://localhost:24817'
+         ansible_ansible_content_hostname: 'http://localhost:24816/pulp/content'
        pulp_default_admin_password: password
        pulp_install_plugins:
          pulp-ansible:


### PR DESCRIPTION
When running pulp_ansible.yml with the vars mentioned in https://pulp-ansible.readthedocs.io/en/latest/installation.html#installation, the playbook fails with below error:

~~~
TASK [pulp : Fail when pulp_secret_key is not set] ****************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'pulp_settings.secret_key is defined' failed. The error was: error while evaluating conditional (pulp_settings.secret_key is defined): 'pulp_settings' is undefined"}
~~~

So modified the vars section in pulp_ansible.yml with correct variables and also added the below variables(https://github.com/pulp/pulp_ansible#configuring-collection-support)

~~~
      ansible_api_hostname: 'http://localhost:24817'
      ansible_ansible_content_hostname: 'http://localhost:24816/pulp/content'
~~~ 