### PR TITLE
 Add test to consume content using mazer

### DIFF
--- a/.travis/ansible_playbook.yml
+++ b/.travis/ansible_playbook.yml
@@ -1,0 +1,36 @@
+---
+- hosts: all
+  pre_tasks:
+    - name: Load DB variables
+      include_vars: '{{ pulp_db_type }}.yml'
+  vars:
+    pulp_default_admin_password: admin
+    pulp_source_dir: '{{ ansible_env.TRAVIS_BUILD_DIR | dirname }}/pulpcore/'
+    pulp_plugin_source_dir: "{{ ansible_env.TRAVIS_BUILD_DIR | dirname }}/pulpcore-plugin"
+    pulp_install_plugins:
+      pulp-ansible:
+        app_label: "ansible"
+        source_dir: "$TRAVIS_BUILD_DIR"
+    ansible_python_interpreter: '/opt/pyenv/shims/python3'
+    pulp_user: 'travis'
+    developer_user: 'travis'
+    pulp_install_db: false
+    pulp_preq_packages: []
+    pulp_settings:
+      content_host: 'localhost:24816'
+      ansible_api_hostname: 'http://localhost:24817'
+      ansible_content_hostname: 'http://localhost:24816/pulp/content'
+      secret_key: 'secret'
+      databases:
+        default:
+          ENGINE: "{{ pulp_db_backend }}"
+          USER: 'travis'
+          PASSWORD: ''
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+  roles:
+    - pulp-database
+    - pulp-workers
+    - pulp-resource-manager
+    - pulp-webserver
+    - pulp-content

--- a/.travis/post_before_install.sh
+++ b/.travis/post_before_install.sh
@@ -1,0 +1,1 @@
+cp .travis/ansible_playbook.yml ../ansible-pulp/playbook.yml

--- a/pulp_ansible/tests/functional/api/collection/test_consume_content.py
+++ b/pulp_ansible/tests/functional/api/collection/test_consume_content.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""Tests that content hosted by Pulp can be consumed by mazer."""
+import unittest
+from functools import reduce
+from urllib.parse import urljoin
+
+from pulp_smash import api, cli, config, exceptions
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import gen_distribution, gen_repo, sync
+
+from pulp_ansible.tests.functional.constants import (
+    ANSIBLE_COLLECTION_REMOTE_PATH,
+    ANSIBLE_DISTRIBUTION_PATH,
+    ANSIBLE_GALAXY_COLLECTION_URL,
+    COLLECTION_WHITELIST,
+)
+from pulp_ansible.tests.functional.utils import gen_ansible_remote
+from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+class MazerConsumeCotentTestCase(unittest.TestCase):
+    """Test whether mazer can install content hosted by Pulp."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg)
+        cls.cli_client = cli.Client(cls.cfg, local=True)
+        try:
+            cls.cli_client.run(["which", "mazer"])
+        except exceptions.CalledProcessError:
+            raise unittest.SkipTest("This test requires mazer client.")
+
+    def test_consume_content(self):
+        """Test whether mazer can install content hosted by Pulp."""
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo["_href"])
+
+        body = gen_ansible_remote(url=ANSIBLE_GALAXY_COLLECTION_URL, whitelist=COLLECTION_WHITELIST)
+        remote = self.client.post(ANSIBLE_COLLECTION_REMOTE_PATH, body)
+        self.addCleanup(self.client.delete, remote["_href"])
+
+        # Sync the repository.
+        self.assertIsNone(repo["_latest_version_href"])
+        sync(self.cfg, remote, repo)
+        repo = self.client.get(repo["_href"])
+
+        # Create distribution
+        distribution = self.client.post(
+            ANSIBLE_DISTRIBUTION_PATH, gen_distribution(repository=repo["_href"])
+        )
+        self.addCleanup(self.client.delete, distribution["_href"])
+
+        galaxy_url = reduce(
+            urljoin, (self.cfg.get_base_url(), "/pulp_ansible/galaxy/", distribution["base_path"])
+        )
+
+        self.cli_client.run(
+            "mazer install {} -c -s {}".format(COLLECTION_WHITELIST, galaxy_url).split()
+        )
+        self.addCleanup(self.cli_client.run, "mazer remove {}".format(COLLECTION_WHITELIST).split())
+
+        response = self.cli_client.run(["mazer", "list"])
+        self.assertIn(COLLECTION_WHITELIST, response.stdout, response)


### PR DESCRIPTION
Add test to consume content hosted by Pulp using mazer.

closes:#4915

Required PR:PulpQE/pulp-smash#1212