### PR TITLE
Removing workaround now that pulpcore RC4 is out

### DIFF
--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -8,10 +8,8 @@ from rest_framework import serializers, viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.parsers import FormParser, MultiPartParser
 
-# workaround until pulpcore-plugin rc4
-# from pulpcore.plugin.exceptions import DigestValidationError
-from pulpcore.exceptions import DigestValidationError
 
+from pulpcore.plugin.exceptions import DigestValidationError
 from pulpcore.plugin.models import Artifact
 from pulpcore.plugin.serializers import (
     AsyncOperationResponseSerializer,


### PR DESCRIPTION
This workarond was only needed until RC4 was released to PyPI. It is out
now so this plugin import can be fixed to import through the plugin API.

[noissue]