### PR TITLE
Refactor routes

### DIFF
--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, path
 
 from pulp_ansible.app.galaxy.views import (
     GalaxyCollectionVersionDetail,
@@ -13,28 +13,26 @@ from pulp_ansible.app.galaxy.views import (
 from pulp_ansible.app.viewsets import CollectionUploadViewSet
 
 
-urlpatterns = [
-    url(r"pulp_ansible/galaxy/(?P<path>.+)/api/$", GalaxyVersionView.as_view()),
-    url(r"ansible/collections/$", CollectionUploadViewSet.as_view({"post": "create"})),
-    url(r"pulp_ansible/galaxy/(?P<path>.+)/api/v1/roles/$", RoleList.as_view()),
-    url(
-        r"pulp_ansible/galaxy/(?P<path>.+)/api/v1/roles/(?P<role_pk>[^/]+)/versions/$",
-        RoleVersionList.as_view(),
-    ),
-    url(r"pulp_ansible/galaxy/(?P<path>.+)/api/v2/collections/$", GalaxyCollectionView.as_view()),
-    url(
-        r"pulp_ansible/galaxy/(?P<path>.+)/api/v2/collections/(?P<namespace>[^/]+)/(?P<name>[^/]+)/"
-        r"$",
-        GalaxyCollectionDetailView.as_view(),
-    ),
-    url(
-        r"pulp_ansible/galaxy/(?P<path>.+)/api/v2/collections/(?P<namespace>[^/]+)/(?P<name>[^/]+)/"
-        r"versions/$",
-        GalaxyCollectionVersionList.as_view(),
-    ),
-    url(
-        r"pulp_ansible/galaxy/(?P<path>.+)/api/v2/collections/(?P<namespace>[^/]+)/(?P<name>[^/]+)/"
-        r"versions/(?P<version>[^/]+)/$",
+galaxy_api_prefix = "pulp_ansible/galaxy/<path:path>/api/"
+
+v1_urls = [
+    path("roles/", RoleList.as_view()),
+    path("roles/<str:role_pk>/versions/", RoleVersionList.as_view()),
+]
+
+v2_urls = [
+    path("collections/", GalaxyCollectionView.as_view()),
+    path("collections/<str:namespace>/<str:name>/", GalaxyCollectionDetailView.as_view()),
+    path("collections/<str:namespace>/<str:name>/versions/", GalaxyCollectionVersionList.as_view()),
+    path(
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/",
         GalaxyCollectionVersionDetail.as_view(),
     ),
+]
+
+urlpatterns = [
+    path("ansible/collections/", CollectionUploadViewSet.as_view({"post": "create"})),
+    path(galaxy_api_prefix, GalaxyVersionView.as_view()),
+    path(galaxy_api_prefix + "v1/", include(v1_urls)),
+    path(galaxy_api_prefix + "v2/", include(v2_urls)),
 ]


### PR DESCRIPTION
* Group URLs into lists by API version.
* Replace usage of deprecated module `django.conf.urls` with
  `django.urls`.
* Replace deprecated regexp-based routes with path routes.