### PR TITLE
Add is_highest field to CollectionVersion model

### DIFF
--- a/CHANGES/5223.misc
+++ b/CHANGES/5223.misc
@@ -1,0 +1,1 @@
+A highest version indicator for a collection version is added.

--- a/pulp_ansible/app/migrations/0005_collectionversion_is_highest.py
+++ b/pulp_ansible/app/migrations/0005_collectionversion_is_highest.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.db import models
+from django.db.models import UniqueConstraint, Q
+import semantic_version as semver
+
+
+def migrate_collection_versions(apps, schema_editor):
+    Collection = apps.get_model("ansible", "Collection")
+    collections = Collection.objects.only('pk').all()
+    for collection in collections:
+        versions = collection.versions.only('pk', 'version').all()
+        highest = max(versions, key=lambda x: semver.Version(x.version))
+        highest.is_highest = True
+        highest.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ansible', '0004_add_fulltext_search_indexes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='collectionversion',
+            name='is_highest',
+            field=models.BooleanField(default=False, editable=False),
+        ),
+        migrations.AddConstraint(
+            model_name='collectionversion',
+            constraint=UniqueConstraint(
+                fields=('collection', 'is_highest'),
+                name='unique_is_highest',
+                condition=Q(is_highest=True)
+            ),
+        ),
+        migrations.RunPython(code=migrate_collection_versions,
+                             reverse_code=migrations.RunPython.noop)
+    ]


### PR DESCRIPTION
`is_highest` is a boolean field that indicates if a specific
collection version has the highest version in a set of available
collection versions.
This patch adds the field, migration and data migration for it.

NOTE: Since the semver comparison is implemented in Python, data
migration fetches all required data into memory. Even considering
limited number of fields that queries fetch, the operation may have
impact on performance or even fail if out of memory.

https://pulp.plan.io/issues/5223
closes #5223