### PR TITLE
WIP: Call galaxy-importer to parse and validate collection

### DIFF
--- a/CHANGES/5239.feature
+++ b/CHANGES/5239.feature
@@ -1,0 +1,1 @@
+Add galaxy-importer into import_collection to parse and validate collection

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-requirements = ["mazer", "packaging", "pulpcore-plugin~=0.1rc3"]
+requirements = ["galaxy_importer==0.1.0", "mazer", "packaging", "pulpcore-plugin~=0.1rc3"]
 
 with open("README.rst") as f:
     long_description = f.read()


### PR DESCRIPTION
Call `galaxy-importer` during the collection import, which performs the parsing and validation of collection data. This PR supports using the validated `metadata` key. 

Note the `galaxy-importer` returning `contents` and `docs_blob` is not yet implemented.

https://pulp.plan.io/issues/5239
closes #5239 
