### PR TITLE
Bugfix when no RepoVersion created yet

### DIFF
--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -4,7 +4,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import viewsets
 from rest_framework import mixins
 
-from pulpcore.app.models import RepositoryVersion, ContentArtifact
+from pulpcore.app.models import Content, ContentArtifact, RepositoryVersion
 from rest_framework.response import Response
 
 from pulp_ansible.app.galaxy.v3.exceptions import ExceptionHandlerMixin
@@ -29,7 +29,11 @@ class AnsibleDistributionMixin:
         if distro.repository_version:
             return distro.repository_version.content
         else:
-            return RepositoryVersion.latest(distro.repository).content
+            repo_version = RepositoryVersion.latest(distro.repository)
+            if repo_version is None:
+                return Content.objects.none()
+            else:
+                return repo_version.content
 
     def get_serializer_context(self):
         """Inserts distribution path to a serializer context."""


### PR DESCRIPTION
When using the V3 Galaxy API implemention in pulp_ansible, it would 500
error when a Repository didn't have a RepsoitoryVersion.

https://pulp.plan.io/issues/5225
closes #5225