### PR TITLE
Auto create RepoVersion on Collection Upload

### DIFF
--- a/CHANGES/5334.feature
+++ b/CHANGES/5334.feature
@@ -1,0 +1,2 @@
+Uploaded collections through the Galaxy V2 and V3 APIs now auto-create a RepositoryVersion for the
+Repository associated with the AnsibleDistribution.


### PR DESCRIPTION
The Galaxy V2 and V3 APIs are accessed through a specific
AnsibleDistribution. If that AnsibleDistribution is related to a
Repository, an upload will create a new RepositoryVersion.

Note: if the AnsibleDsitribution is serving a specific RepositoryVersion
(not "the latest" from a Repository), no additional RepositoryVersions
are created).

https://pulp.plan.io/issues/5334
closes #5334