### PR TITLE
Fix S3 files not having path attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    "galaxy_importer==0.1.3b5",
+    "galaxy_importer==0.1.3b8",
     "packaging",
     "pulpcore-plugin~=0.1rc3",
     "PyYAML",


### PR DESCRIPTION
This patch replaces `artifact.file.path` attribute usage, which
may not be implemented for all types of django file storage,
with using django File interface, specifically an `open()` method
to work with artifact as a python file-like object.

DependsOn: ansible/galaxy-importer#29