### PR TITLE
Return collection version 'namespace' as a dict (Fixes #5459)

### DIFF
--- a/CHANGES/5459.bugfix
+++ b/CHANGES/5459.bugfix
@@ -1,0 +1,2 @@
+Fix CollectionVersion view imcompatibilty with ansible-galaxy.
+Fixes ansible issue https://github.com/ansible/ansible/issues/62076

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -131,6 +131,14 @@ class CollectionMetadataSerializer(serializers.ModelSerializer):
         )
 
 
+class CollectionNamespaceSerializer(serializers.Serializer):
+    """
+    A serializer for a Collection Version namespace field.
+    """
+
+    name = serializers.CharField(source="namespace")
+
+
 class CollectionVersionSerializer(CollectionVersionListSerializer):
     """
     A serializer for a CollectionVersion.
@@ -141,6 +149,7 @@ class CollectionVersionSerializer(CollectionVersionListSerializer):
     download_url = serializers.SerializerMethodField()
 
     metadata = CollectionMetadataSerializer(source="*")
+    namespace = CollectionNamespaceSerializer(source="*")
 
     class Meta(CollectionVersionListSerializer.Meta):
         fields = CollectionVersionListSerializer.Meta.fields + (


### PR DESCRIPTION
https://pulp.plan.io/issues/5459
closes #5459