### PR TITLE
Updating ansible to 2.9.0b1

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ansible/ansible.git@devel#egg=ansible
+ansible==2.9.0b1
 coverage
 flake8
 flake8-black


### PR DESCRIPTION
Updating ansible to 2.9.0b1 because galaxy_importer requires it.

[noissue]