### PR TITLE
Revert "add new upload serializer"

### DIFF
--- a/CHANGES/5555.bugfix
+++ b/CHANGES/5555.bugfix
@@ -1,0 +1,1 @@
+Reverting back to the older upload serializers.

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -12,7 +12,7 @@ from pulp_ansible.app.galaxy.views import (
 )
 from pulp_ansible.app.galaxy.v3 import views as views_v3
 
-from pulp_ansible.app.viewsets import CollectionVersionViewSet
+from pulp_ansible.app.viewsets import CollectionUploadViewSet
 
 
 GALAXY_API_ROOT = getattr(settings, "GALAXY_API_ROOT", "pulp_ansible/galaxy/<path:path>/api/")
@@ -39,7 +39,7 @@ v3_urls = [
     ),
     path(
         "artifacts/collections/",
-        views_v3.CollectionVersionViewSet.as_view({"post": "create"}),
+        views_v3.CollectionUploadViewSet.as_view({"post": "create"}),
         name="collection-artifact-upload",
     ),
     path(
@@ -72,7 +72,7 @@ v3_urls = [
 ]
 
 urlpatterns = [
-    path("ansible/collections/", CollectionVersionViewSet.as_view({"post": "create"})),
+    path("ansible/collections/", CollectionUploadViewSet.as_view({"post": "create"})),
     path(GALAXY_API_ROOT, GalaxyVersionView.as_view()),
     path(GALAXY_API_ROOT + "v1/", include(v1_urls)),
     path(GALAXY_API_ROOT + "v2/", include(v2_urls)),

--- a/pulp_ansible/tests/functional/api/collection/test_upload.py
+++ b/pulp_ansible/tests/functional/api/collection/test_upload.py
@@ -1,13 +1,13 @@
 # coding=utf-8
 """Tests related to upload of collections."""
+import hashlib
 import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config
-from pulp_smash.exceptions import TaskReportError
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import delete_orphans
 from pulp_smash.utils import http_get
+from requests.exceptions import HTTPError
 
 from pulp_ansible.tests.functional.constants import (
     ANSIBLE_COLLECTION_FILE_NAME,
@@ -28,11 +28,8 @@ class UploadCollectionTestCase(unittest.TestCase):
         cls.client = api.Client(cls.cfg)
 
         collection_content = http_get(ANSIBLE_COLLECTION_UPLOAD_FIXTURE_URL)
-        artifact = cls.client.post(ARTIFACTS_PATH, files={"file": collection_content})
-        cls.collection = {
-            "artifact": artifact["_href"],
-            "relative_path": ANSIBLE_COLLECTION_FILE_NAME,
-        }
+        cls.collection = {"file": (ANSIBLE_COLLECTION_FILE_NAME, collection_content)}
+        cls.collection_sha256 = hashlib.sha256(collection_content).hexdigest()
 
     def test_collection_upload(self):
         """Upload a collection.
@@ -42,19 +39,19 @@ class UploadCollectionTestCase(unittest.TestCase):
         * `Pulp #5262 <https://pulp.plan.io/issues/5262>`_
         """
         UPLOAD_PATH = urljoin(self.cfg.get_base_url(), "ansible/collections/")
-        response = self.client.using_handler(api.task_handler).post(UPLOAD_PATH, self.collection)
+        response = self.client.post(UPLOAD_PATH, files=self.collection)
 
         for key, value in response.items():
             with self.subTest(key=key):
                 if key in COLLECTION_METADATA.keys():
                     self.assertEqual(COLLECTION_METADATA[key], value, response)
 
-        with self.assertRaises(TaskReportError) as ctx:
-            self.client.using_handler(api.task_handler).post(UPLOAD_PATH, self.collection)
+        self.assertEqual(response["sha256"], self.collection_sha256, response)
 
-        for key in ("collection_version", "name", "namespace", "version"):
-            self.assertIn(
-                key, ctx.exception.task["error"]["description"].lower(), ctx.exception.task["error"]
-            )
+        with self.assertRaises(HTTPError) as ctx:
+            self.client.using_handler(api.code_handler).post(UPLOAD_PATH, files=self.collection)
+
+        for key in ("artifact", "already", "exists"):
+            self.assertIn(key, ctx.exception.response.json()[0].lower(), ctx.exception.response)
 
         delete_orphans(self.cfg)


### PR DESCRIPTION
This reverts commit acc5c3ebdb1d7d901f271614305d7e88386504ef.

The Automation Hub project relied on the current behaviors of V3 API
adn this broke them. We do not have functional test coverage for
pulp_ansible in that area yet.

We hope to receive functional tests from them soon, which will allow us
to port onto the SingleContentArtifactUploadViewset and corresponding
serializer with confidence then.

https://pulp.plan.io/issues/5555
closes #5555