### PR TITLE
Fix assertion error about missing serializer_class

### DIFF
--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -171,6 +171,7 @@ class CollectionVersionViewSet(
 
     authentication_classes = []
     permission_classes = []
+    serializer_class = CollectionVersionSerializer
 
     lookup_field = "version"
 


### PR DESCRIPTION
AssertionError: 'CollectionVersionViewSet' should either include a
`serializer_class` attribute, or override the `get_serializer_class()`
method.

[noissue]