### PR TITLE
Creating a CollectionImport immediately after the task

### DIFF
--- a/CHANGES/5569.bugfix
+++ b/CHANGES/5569.bugfix
@@ -1,0 +1,1 @@
+Fix bug where CollectionImport was not being created in viewset causing 404s for galaxy.

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -151,6 +151,7 @@ class CollectionUploadViewSet(ExceptionHandlerMixin, viewsets.GenericViewSet):
             kwargs["repository_pk"] = distro.repository.pk
 
         async_result = enqueue_with_reservation(import_collection, locks, kwargs=kwargs)
+        CollectionImport.objects.create(task_id=async_result.id)
 
         data = {
             "task": reverse(


### PR DESCRIPTION
Galaxy was polling the CollectionImport which wasn't being created until
the task started. This caused 404s.

fixes #5569