### PR TITLE
Problem: CI with old plugin-template fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ addons:
   postgresql: '9.6'
 before_install: .travis/before_install.sh
 install: .travis/install.sh
-before_script: .travis/before_script.sh
-script: .travis/script.sh
+before_script: PULP_SETTINGS=/etc/pulp/settings.py .travis/before_script.sh
+script: PULP_SETTINGS=/etc/pulp/settings.py .travis/script.sh
 after_failure:
   - sh -c "cat ~/django_runserver.log"
   - sh -c "cat ~/resource_manager.log"
@@ -47,29 +47,29 @@ after_failure:
 jobs:
   include:
   - stage: deploy-plugin-to-pypi
-    script:  bash .travis/publish_plugin_pypi.sh
+    script:  PULP_SETTINGS=/etc/pulp/settings.py bash .travis/publish_plugin_pypi.sh
     if: tag IS present
 
   - stage: publish-daily-client-gem
-    script: bash .travis/publish_client_gem.sh
+    script: PULP_SETTINGS=/etc/pulp/settings.py bash .travis/publish_client_gem.sh
     env:
       - DB=postgres
       - TEST=bindings
     if: type = cron
   - stage: publish-daily-client-pypi
-    script: bash .travis/publish_client_pypi.sh
+    script: PULP_SETTINGS=/etc/pulp/settings.py bash .travis/publish_client_pypi.sh
     env:
       - DB=postgres
       - TEST=bindings
     if: type = cron
   - stage: publish-client-gem
-    script: bash .travis/publish_client_gem.sh
+    script: PULP_SETTINGS=/etc/pulp/settings.py bash .travis/publish_client_gem.sh
     env:
       - DB=postgres
       - TEST=bindings
     if: tag IS present
   - stage: publish-client-pypi
-    script: bash .travis/publish_client_pypi.sh
+    script: PULP_SETTINGS=/etc/pulp/settings.py bash .travis/publish_client_pypi.sh
     env:
       - DB=postgres
       - TEST=bindings


### PR DESCRIPTION
due to PULP_SETTINGS being unset for multiple commands like django-admin.

Solution: Set PULP_SETTINGS in .travis.yml

re: #5560
PULP_SETTINGS environment variable does not work
https://pulp.plan.io/issues/5560

[noissue]