### PR TITLE
Use CONTENT_ORIGIN instead of CONTENT_HOST

### DIFF
--- a/.travis/playbook.yml
+++ b/.travis/playbook.yml
@@ -22,7 +22,7 @@
     pulp_install_db: false
     pulp_preq_packages: []
     pulp_settings:
-      content_host: 'localhost:24816'
+      content_origin: 'localhost:24816'
       secret_key: 'secret'
       databases:
         default:

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -111,7 +111,7 @@ show_logs_and_return_non_zero() {
 sudo systemctl stop pulpcore-worker* pulpcore-resource-manager pulpcore-content pulpcore-api
 
 # Start services with logs and coverage
-export PULP_CONTENT_HOST=localhost:24816
+export PULP_CONTENT_ORIGIN=localhost:24816
 rq worker -n 'resource-manager@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig' >> ~/resource_manager.log 2>&1 &
 rq worker -n 'reserved-resource-worker-1@%h' -w 'pulpcore.tasking.worker.PulpWorker' -c 'pulpcore.rqconfig' >> ~/reserved_worker-1.log 2>&1 &
 gunicorn pulpcore.tests.functional.content_with_coverage:server --bind 'localhost:24816' --worker-class 'aiohttp.GunicornWebWorker' -w 2 >> ~/content_app.log 2>&1 &

--- a/CHANGES/5629.misc
+++ b/CHANGES/5629.misc
@@ -1,0 +1,1 @@
+Switch to using ``CONTENT_ORIGIN`` instead of ``CONTENT_HOST`` due to core changing the name.

--- a/docs/workflows/distribution.rst
+++ b/docs/workflows/distribution.rst
@@ -10,7 +10,7 @@ Create a Distribution for Repository 'foo'
 
 This will distribute the 'latest' RepositoryVersion always which makes it consumable by
 ``ansible-galaxy`` client. Users create a Distribution which will serve the RepositoryVersion
-content at ``$CONTENT_HOST/pulp/content/<distribution.base_path>`` as demonstrated in the
+content at ``$CONTENT_ORIGIN/pulp/content/<distribution.base_path>`` as demonstrated in the
 :ref:`ansible-galaxy usage documentation<ansible-galaxy-cli>`.
 
 .. literalinclude:: ../_scripts/distribution_repo.sh

--- a/pulp_ansible/app/galaxy/serializers.py
+++ b/pulp_ansible/app/galaxy/serializers.py
@@ -40,8 +40,8 @@ class GalaxyRoleVersionSerializer(serializers.Serializer):
         """
         Get source.
         """
-        if settings.CONTENT_HOST:
-            host = settings.CONTENT_HOST
+        if settings.CONTENT_ORIGIN:
+            host = settings.CONTENT_ORIGIN
         else:
             host = self.context["request"].get_host()
         host = "{}://{}".format(self.context["request"].scheme, host)

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -181,7 +181,7 @@ class CollectionVersionSerializer(CollectionVersionListSerializer):
         """
         Get artifact download URL.
         """
-        host = settings.CONTENT_HOST.strip("/")
+        host = settings.CONTENT_ORIGIN.strip("/")
         prefix = settings.CONTENT_PATH_PREFIX.strip("/")
         base_path = self.context["content_artifact"].relative_path.lstrip("/")
         return f"{host}/{prefix}/{base_path}"


### PR DESCRIPTION
pulpcore changed the setting name from CONTENT_HOST to CONTENT_ORIGIN.

Required PR: https://github.com/pulp/pulpcore/pull/353
Required PR: https://github.com/pulp/pulp_file/pull/300

https://pulp.plan.io/issues/5629
re #5629