### PR TITLE
Use latest galaxy_importer which now uses latest ansible

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,4 @@
-# use 2.9 stable until https://github.com/ansible/ansible/pull/63473 is released
-git+https://github.com/ansible/ansible.git@stable-2.9#egg=ansible
+ansible
 coverage
 flake8
 flake8-black

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    "galaxy_importer==0.1.3b11",
+    "galaxy_importer",
     "packaging",
     "pulpcore~=3.0rc7",
     "PyYAML",


### PR DESCRIPTION
Uses the latest galaxy_importer on pypi, currently `0.1.3` which uses the latest `ansible`, currently `2.9.0`