### PR TITLE
fix rendering of systemd settings in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ would be::
     export PULP_ANSIBLE_API_HOSTNAME='http://localhost:24817'
     export PULP_ANSIBLE_CONTENT_HOSTNAME='http://localhost:24816/pulp/content'
 
-or in your systemd environment:
+or in your systemd environment::
 
     Environment="PULP_ANSIBLE_API_HOSTNAME=http://localhost:24817"
     Environment="PULP_ANSIBLE_CONTENT_HOSTNAME=http://localhost:24816/pulp/content"


### PR DESCRIPTION
you need a double-colon to make rST render the next section a code