### PR TITLE
Adds nginx and apache fragments for the installer

### DIFF
--- a/CHANGES/6188.misc
+++ b/CHANGES/6188.misc
@@ -1,0 +1,1 @@
+Adds nginx and apache fragments so the installer can install them.

--- a/pulp_ansible/app/webserver_snippets/apache.conf
+++ b/pulp_ansible/app/webserver_snippets/apache.conf
@@ -1,0 +1,2 @@
+ProxyPass /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy
+ProxyPassReverse /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy

--- a/pulp_ansible/app/webserver_snippets/nginx.conf
+++ b/pulp_ansible/app/webserver_snippets/nginx.conf
@@ -1,0 +1,9 @@
+location /pulp_ansible/galaxy/ {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Host $http_host;
+    # we don't want nginx trying to do something clever with
+    # redirects, we set the Host: header above already.
+    proxy_redirect off;
+    proxy_pass http://pulp-api;
+}


### PR DESCRIPTION
The installer is getting a feature that can symlink to config fragments
provided by plugins.

https://pulp.plan.io/issues/6188
closes #6188