### PR TITLE
Fix ansible-galaxy CLI issue with 2.10.0

### DIFF
--- a/CHANGES/6239.bugfix
+++ b/CHANGES/6239.bugfix
@@ -1,0 +1,1 @@
+Fix 404 error with ansible-galaxy 2.10.0 while staying compatible with 2.9.z CLI clients also.

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -32,7 +32,7 @@ v2_urls = [
         GalaxyCollectionVersionDetail.as_view(),
     ),
     path(
-        "collection-imports/<uuid:pk>",
+        "collection-imports/<uuid:pk>/",
         views_v3.CollectionImportViewSet.as_view({"get": "retrieve"}),
     ),
 ]


### PR DESCRIPTION
A trailing slash is needed so a new optimization in the CLI will still
allow uploads to work. Existing 2.9.0 clients will also stay working
with this change.

https://pulp.plan.io/issues/6239
closes #6239