### PR TITLE
Include cli tests in package

### DIFF
--- a/CHANGES/6250.misc
+++ b/CHANGES/6250.misc
@@ -1,0 +1,1 @@
+Ensure the packaged version includes the ``pulp_ansible.functional.cli`` tests.


### PR DESCRIPTION
The pulp_ansible.functional.cli package was missing an __init__.py

https://pulp.plan.io/issues/6250
closes #6250