### PR TITLE
Rename ansible-pulp to pulp_installer

### DIFF
--- a/docs/bindings.rst
+++ b/docs/bindings.rst
@@ -56,9 +56,9 @@ started with openapi-generator-cli is available on
 Generating a client on dev environment
 --------------------------------------
 
-Pulp dev environment provided by `ansible-pulp <https://github.com/pulp/ansible-pulp>`_
+Pulp dev environment provided by `pulp_installer <https://github.com/pulp/pulp_installer>`_
 introduces a set of useful
-`aliases <https://github.com/pulp/ansible-pulp/tree/master/roles/pulp-devel#aliases>`_,
+`aliases <https://github.com/pulp/pulp_installer/tree/master/roles/pulp-devel#aliases>`_,
 like `pbindings`.
 
 Examples:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,13 +4,13 @@ Installation
 Install using Ansible
 ---------------------
 
-pulpcore provides an `Ansible Installer <https://github.com/pulp/ansible-pulp>`_ that can be used to
+pulpcore provides an `Ansible Installer <https://github.com/pulp/pulp_installer>`_ that can be used to
 install ``pulp_ansible``. For example if your host is in your Ansible inventory as ``myhost`` you
 can install onto it with:
 
 .. code-block:: bash
 
-    git clone https://github.com/pulp/ansible-pulp.git
+    git clone https://github.com/pulp/pulp_installer.git
 
 Create your pulp_ansible.yml playbook to use with the installer:
 


### PR DESCRIPTION
[noissue]

re: #6406
Rename ansible-pulp to pulp_installer
https://pulp.plan.io/issues/6406