### PR TITLE
Release 0.2.0b12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,25 @@ Changelog
 
 .. towncrier release notes start
 
+0.2.0b12 (2020-04-30)
+=====================
+
+Improved Documentation
+----------------------
+
+- Documented bindings installation on dev environment
+  `#6390 <https://pulp.plan.io/issues/6390>`_
+
+
+Misc
+----
+
+- `#6391 <https://pulp.plan.io/issues/6391>`_
+
+
+----
+
+
 0.2.0b11 (2020-03-13)
 =====================
 

--- a/CHANGES/6390.doc
+++ b/CHANGES/6390.doc
@@ -1,1 +1,0 @@
-Documented bindings installation on dev environment

--- a/CHANGES/6391.misc
+++ b/CHANGES/6391.misc
@@ -1,1 +1,0 @@
-Get bindings config from pulp-smash

--- a/pulp_ansible/__init__.py
+++ b/pulp_ansible/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0b12.dev"
+__version__ = "0.2.0b12"
 
 default_app_config = "pulp_ansible.app.PulpAnsiblePluginAppConfig"

--- a/pulp_ansible/__init__.py
+++ b/pulp_ansible/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.2.0b12"
+__version__ = "0.2.0b13.dev"
 
 default_app_config = "pulp_ansible.app.PulpAnsiblePluginAppConfig"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 requirements = [
     "galaxy_importer",
     "packaging",
-    "pulpcore>=3.0,<3.4",
+    "pulpcore>=3.0",
     "PyYAML",
     "semantic_version",
 ]
@@ -15,7 +15,7 @@ with open("README.rst") as f:
 
 setup(
     name="pulp-ansible",
-    version="0.2.0b12",
+    version="0.2.0b13.dev",
     description="Pulp plugin to manage Ansible content, e.g. roles",
     long_description=long_description,
     license="GPLv2+",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 requirements = [
     "galaxy_importer",
     "packaging",
-    "pulpcore>=3.0",
+    "pulpcore>=3.0,<3.4",
     "PyYAML",
     "semantic_version",
 ]
@@ -15,7 +15,7 @@ with open("README.rst") as f:
 
 setup(
     name="pulp-ansible",
-    version="0.2.0b12.dev",
+    version="0.2.0b12",
     description="Pulp plugin to manage Ansible content, e.g. roles",
     long_description=long_description,
     license="GPLv2+",


### PR DESCRIPTION
Solving conflict due `galaxy_ng` and `pulp_container` requiring `pulpcore` 3.3
```
"There are incompatible versions in the resolved dependencies:", 
"  pulpcore==3.3.0 (from -r requirements.in (line 1))", 
"  pulpcore<3.3,>=3.0 (from pulp-ansible==0.2.0b11->-r requirements.in (line 2))", 
"  pulpcore<3.4,>=3.0 (from galaxy-ng==4.2.0a5->-r requirements.in (line 3))", 
"  pulpcore<3.4,>=3.3 (from pulp-container==1.3.0->-r requirements.in (line 4))"],
```