### PR TITLE
Pagination query params according to API versions

### DIFF
--- a/CHANGES/7396.bugfix
+++ b/CHANGES/7396.bugfix
@@ -1,0 +1,3 @@
+Pagination query params according to API versions.
+v1 and v2 - `page` and `page_size`
+v3 or above - `offset` and `limit`

--- a/CHANGES/7435.removal
+++ b/CHANGES/7435.removal
@@ -1,0 +1,1 @@
+Changed V3 pagination to match Galaxy V3 API pagination

--- a/pulp_ansible/app/galaxy/v3/pagination.py
+++ b/pulp_ansible/app/galaxy/v3/pagination.py
@@ -1,0 +1,84 @@
+from rest_framework import pagination
+from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param, replace_query_param
+
+
+class LimitOffsetPagination(pagination.LimitOffsetPagination):
+    """
+    Pagination for V3.
+
+    """
+
+    default_limit = 10
+    max_limit = 100
+
+    def get_first_link(self):
+        """First link."""
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        return replace_query_param(url, self.offset_query_param, 0)
+
+    def get_last_link(self):
+        """Last link."""
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        offset = self.count - self.limit if (self.count - self.limit) >= 0 else 0
+        return replace_query_param(url, self.offset_query_param, offset)
+
+    def get_next_link(self):
+        """Next link."""
+        if self.offset + self.limit >= self.count:
+            return None
+
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        offset = self.offset + self.limit
+        return replace_query_param(url, self.offset_query_param, offset)
+
+    def get_previous_link(self):
+        """Previous link."""
+        if self.offset <= 0:
+            return None
+
+        url = self.request.get_full_path()
+        url = replace_query_param(url, self.limit_query_param, self.limit)
+
+        if self.offset - self.limit <= 0:
+            return remove_query_param(url, self.offset_query_param)
+
+        offset = self.offset - self.limit
+        return replace_query_param(url, self.offset_query_param, offset)
+
+    def get_paginated_response(self, data):
+        """Returns paginated response."""
+        return Response(
+            {
+                "meta": {"count": self.count},
+                "links": {
+                    "first": self.get_first_link(),
+                    "previous": self.get_previous_link(),
+                    "next": self.get_next_link(),
+                    "last": self.get_last_link(),
+                },
+                "data": data,
+            }
+        )
+
+    # Custom methods for working with pulp client
+    def init_from_request(self, request):
+        """Init form request."""
+        self.request = request
+        self.offset = self.get_offset(request)
+        self.limit = self.get_limit(request)
+
+    def paginate_proxy_response(self, data, count):
+        """Paginate proxy response."""
+        self.count = count
+
+        if self.count > self.limit and self.template is not None:
+            self.display_page_controls = True
+
+        return self.get_paginated_response(data)

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -30,6 +30,7 @@ from pulp_ansible.app.serializers import (
 )
 
 from pulp_ansible.app.galaxy.mixins import UploadGalaxyCollectionMixin
+from pulp_ansible.app.galaxy.v3.pagination import LimitOffsetPagination
 from pulp_ansible.app.viewsets import CollectionVersionFilter
 
 
@@ -73,6 +74,7 @@ class CollectionViewSet(
     authentication_classes = []
     permission_classes = []
     serializer_class = CollectionSerializer
+    pagination_class = LimitOffsetPagination
 
     def get_queryset(self):
         """
@@ -184,6 +186,7 @@ class CollectionVersionViewSet(
     permission_classes = []
     serializer_class = CollectionVersionSerializer
     filterset_class = CollectionVersionFilter
+    pagination_class = LimitOffsetPagination
 
     lookup_field = "version"
 

--- a/pulp_ansible/app/galaxy/views.py
+++ b/pulp_ansible/app/galaxy/views.py
@@ -167,6 +167,7 @@ class GalaxyCollectionVersionList(generics.ListAPIView):
 
     model = CollectionVersion
     serializer_class = GalaxyCollectionVersionSerializer
+    pagination_class = pagination.PageNumberPagination
     authentication_classes = []
     permission_classes = []
 

--- a/pulp_ansible/app/tasks/roles.py
+++ b/pulp_ansible/app/tasks/roles.py
@@ -14,7 +14,7 @@ from pulpcore.plugin.stages import (
 )
 from pulp_ansible.app.constants import PAGE_SIZE
 from pulp_ansible.app.models import RoleRemote, Role
-from pulp_ansible.app.tasks.utils import get_page_url, parse_metadata
+from pulp_ansible.app.tasks.utils import get_api_version, get_page_url, parse_metadata
 
 
 log = logging.getLogger(__name__)
@@ -130,7 +130,8 @@ class RoleFirstStage(Stage):
 
         progress_data = dict(message="Parsing Pages from Galaxy Roles API", code="parsing.roles")
         with ProgressReport(**progress_data) as progress_bar:
-            downloader = remote.get_downloader(url=get_page_url(remote.url))
+            api_version = get_api_version(remote.url)
+            downloader = remote.get_downloader(url=get_page_url(remote.url, api_version))
             metadata = parse_metadata(await downloader.run())
 
             page_count = math.ceil(float(metadata["count"]) / float(PAGE_SIZE))
@@ -142,7 +143,7 @@ class RoleFirstStage(Stage):
 
             # Concurrent downloads are limited by aiohttp...
             not_done = set(
-                remote.get_downloader(url=get_page_url(remote.url, page)).run()
+                remote.get_downloader(url=get_page_url(remote.url, api_version, page)).run()
                 for page in range(2, page_count + 1)
             )
 

--- a/pulp_ansible/tests/functional/api/collection/v3/test_collection.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_collection.py
@@ -185,8 +185,8 @@ def test_collection_version_list(artifact, pulp_client, collection_detail):
     """Test the versions endpoint, listing the available versions of a given collection."""
     # Version List Endpoint
     versions = pulp_client.using_handler(api.json_handler).get(collection_detail["versions_url"])
-    assert versions["count"] == 1
-    version = versions["results"][0]
+    assert versions["meta"]["count"] == 1
+    version = versions["data"][0]
 
     assert version["version"] == "1.0.0"
     assert version["certification"] == "needs_review"


### PR DESCRIPTION
https://pulp.plan.io/issues/7396
closes #7396

AH
```
GET /api/automation-hub/v3/collections/
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "meta": {
        "count": 61
    },
    "links": {
        "first": "/api/automation-hub/v3/collections/?limit=10&offset=0",
        "previous": null,
        "next": "/api/automation-hub/v3/collections/?limit=10&offset=10",
        "last": "/api/automation-hub/v3/collections/?limit=10&offset=51"
    },
    "data": [
```

Galaxy
```
GET /api/v2/collections/?page=1&page_size=1
HTTP 200 OK
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "count": 595,
    "next": "/api/v2/collections/?page=2&page_size=1",
    "next_link": "/api/v2/collections/?page=2&page_size=1",
    "previous": null,
    "previous_link": null,
    "results": [
```