### PR TITLE
Fix get_api_version  regex

### DIFF
--- a/pulp_ansible/app/tasks/utils.py
+++ b/pulp_ansible/app/tasks/utils.py
@@ -12,8 +12,8 @@ from pulp_ansible.app.constants import PAGE_SIZE
 
 def get_api_version(url):
     """Get API version."""
-    result = re.findall(r"/api/v(\d)", url)
-    if len(result) != 1:
+    result = re.findall(r"/v(\d)/", url)
+    if len(result) == 0:
         raise RuntimeError("Could not determine Galaxy API version")
     return int(result[0])
 


### PR DESCRIPTION
[noissue]

```
In [1]: import re

In [2]: re.findall(r"/api(?:/automation-hub)?/v(\d)", "https://galaxy.ansible.com/api/v2/collections")
Out[2]: ['2']

In [3]: re.findall(r"/api(?:/automation-hub)?/v(\d)", "https://cloud.redhat.com/api/automation-hub/v3/collections")
Out[3]: ['3']
```