### PR TITLE
Removes the ``test_file_decriptors`` test

### DIFF
--- a/CHANGES/7453.misc
+++ b/CHANGES/7453.misc
@@ -1,0 +1,2 @@
+Removes the ``test_file_decriptors`` test which was not actually testing Pulp code and was failing
+intermittently.

--- a/pulp_ansible/tests/functional/api/role/test_sync.py
+++ b/pulp_ansible/tests/functional/api/role/test_sync.py
@@ -2,8 +2,7 @@
 """Tests that sync ansible plugin repositories."""
 import unittest
 
-from pulp_smash import api, cli, config, exceptions
-from pulp_smash.pulp3.constants import MEDIA_PATH
+from pulp_smash import api, config, exceptions
 from pulp_smash.pulp3.utils import gen_repo, get_added_content_summary, get_content_summary, sync
 
 from pulp_ansible.tests.functional.constants import (
@@ -23,37 +22,6 @@ class BasicSyncTestCase(unittest.TestCase):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
-
-    def test_file_decriptors(self):
-        """Test whether file descriptors are closed properly.
-
-        This test targets the following issue:
-        `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
-
-        Do the following:
-        1. Check if 'lsof' is installed. If it is not, skip this test.
-        2. Create and sync a repo.
-        3. Run the 'lsof' command to verify that files in the
-           path ``/var/lib/pulp/`` are closed after the sync.
-        4. Assert that issued command returns `0` opened files.
-        """
-        cli_client = cli.Client(self.cfg, cli.echo_handler)
-
-        # check if 'lsof' is available
-        if cli_client.run(("which", "lsof")).returncode != 0:
-            raise unittest.SkipTest("lsof package is not present")
-
-        repo = self.client.post(ANSIBLE_REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo["pulp_href"])
-
-        remote = self.client.post(ANSIBLE_REMOTE_PATH, gen_ansible_remote())
-        self.addCleanup(self.client.delete, remote["pulp_href"])
-
-        sync(self.cfg, remote, repo)
-
-        cmd = "lsof -t +D {}".format(MEDIA_PATH).split()
-        response = cli_client.run(cmd).stdout
-        self.assertEqual(len(response), 0, response)
 
     def test_sync(self):
         """Sync repositories with the ansible plugin.


### PR DESCRIPTION
Removes the ``test_file_decriptors`` test which was not actually testing Pulp
code and was failing intermittently.

closes #7453