### PR TITLE
Version bump 0.4.1.dev and CI config updates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1.dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+))?

--- a/pulp_ansible/__init__.py
+++ b/pulp_ansible/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1.dev"
 
 default_app_config = "pulp_ansible.app.PulpAnsiblePluginAppConfig"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as f:
 
 setup(
     name="pulp-ansible",
-    version="0.4.0",
+    version="0.4.1.dev",
     description="Pulp plugin to manage Ansible content, e.g. roles",
     long_description=long_description,
     license="GPLv2+",

--- a/template_config.yml
+++ b/template_config.yml
@@ -30,8 +30,8 @@ publish_docs_to_pulpprojectdotorg: true
 pulp_settings:
   ansible_api_hostname: http://pulp:80
   ansible_content_hostname: http://pulp:80/pulp/content
-pulpcore_branch: master
-pulpcore_pip_version_specifier: null
+pulpcore_branch: 3.7
+pulpcore_pip_version_specifier: ~=3.7.0
 pulpprojectdotorg_key_id: aa499d7938ed
 pydocstyle: true
 pypi_username: pulp


### PR DESCRIPTION
* Now at 0.4.1.dev in prep for next z-stream release
* Declared compatability with pulpcore 3.7.0 in CI variables

[noissue]