### PR TITLE
Fix docs_blob downloading handler

### DIFF
--- a/CHANGES/7551.bugfix
+++ b/CHANGES/7551.bugfix
@@ -1,0 +1,1 @@
+Fixing docs-blob file parser

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -428,8 +428,9 @@ class DocsBlobDownloader(ArtifactDownloader):
                 )
                 try:
                     download_result = await downloader.run()
-                    with open(download_result.path, "r") as docs_blob:
-                        d_content.extra_data["docs_blob"] = json.load(docs_blob)
+                    with open(download_result.path, "r") as docs_blob_file:
+                        docs_blob_json = json.load(docs_blob_file)
+                        d_content.extra_data["docs_blob"] = docs_blob_json.get("docs_blob", {})
                 except FileNotFoundError:
                     pass
 


### PR DESCRIPTION
Avoiding:
```
{docs_blob": { "docs_blob": {...
```
Ref: https://pulp.plan.io/issues/7551#note-1