### PR TITLE
Fix galaxy collection endpoint results for empty repos

### DIFF
--- a/CHANGES/7669.bugfix
+++ b/CHANGES/7669.bugfix
@@ -1,0 +1,1 @@
+Fix galaxy collection endpoint results for empty repos

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -125,6 +125,9 @@ class CollectionViewSet(
             if not value or semantic_version.Version(version) > semantic_version.Version(value):
                 collection_versions[str(collection_id)] = version
 
+        if not collection_versions.items():
+            return CollectionVersion.objects.none()
+
         query_params = Q()
         for collection_id, version in collection_versions.items():
             query_params |= Q(collection_id=collection_id, version=version)


### PR DESCRIPTION
https://pulp.plan.io/issues/7669
closes #7669