### PR TITLE
Improve regex to determine the API version

### DIFF
--- a/CHANGES/7711.bugfix
+++ b/CHANGES/7711.bugfix
@@ -1,0 +1,1 @@
+Improve regex to determine the API version

--- a/pulp_ansible/app/tasks/utils.py
+++ b/pulp_ansible/app/tasks/utils.py
@@ -12,7 +12,7 @@ from pulp_ansible.app.constants import PAGE_SIZE
 
 def get_api_version(url):
     """Get API version."""
-    result = re.findall(r"/v(\d)/", url)
+    result = re.findall(r"/v(\d)", url)
     if len(result) == 0:
         raise RuntimeError(f"Could not determine API version for: {url}")
     return int(result[0])


### PR DESCRIPTION
The regex was expecting a slash after the API version, which may conflict with  trailing slash validation

closes #7711