### PR TITLE
Fix ansible collection version > 32 chars

### DIFF
--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -147,7 +147,7 @@ class CollectionVersion(Content):
     name = models.CharField(max_length=64, editable=False)
     namespace = models.CharField(max_length=32, editable=False)
     repository = models.CharField(default="", blank=True, max_length=2000, editable=False)
-    version = models.CharField(max_length=32, editable=False)
+    version = models.CharField(max_length=64, editable=False)
 
     is_highest = models.BooleanField(editable=False, default=False)
     certification = models.CharField(


### PR DESCRIPTION
Ansible collections version references might be bigger
than 32 characters. As example the ansible community.
general version can be checked
https://galaxy.ansible.com/api/v2/collections/community/general/versions

closes #7745
https://pulp.plan.io/issues/7745