### PR TITLE
Allow CollectionUploadViewSet subclass to set own serializer

### DIFF
--- a/CHANGES/7788.feature
+++ b/CHANGES/7788.feature
@@ -1,0 +1,1 @@
+Allow CollectionUploadViewSet subclass to set own serializer


### PR DESCRIPTION
Changelog from: https://github.com/pulp/pulp_ansible/pull/407
closes #7788