### PR TITLE
Adds validation to `CollectionRemoteSerializer`

### DIFF
--- a/CHANGES/7802.bugfix
+++ b/CHANGES/7802.bugfix
@@ -1,0 +1,2 @@
+Ensure that when creating a ``CollectionRemote`` with either a ``token`` or ``auth_url`` that you
+use both together.

--- a/pulp_ansible/app/downloaders.py
+++ b/pulp_ansible/app/downloaders.py
@@ -49,7 +49,7 @@ class TokenAuthHttpDownloader(HttpDownloader):
         Initialize the downloader.
         """
         self.ansible_auth_url = auth_url
-        self.ansible_token = token
+        self.token = token
         if silence_errors_for_response_status_codes is None:
             silence_errors_for_response_status_codes = set()
         self.silence_errors_for_response_status_codes = silence_errors_for_response_status_codes
@@ -83,18 +83,10 @@ class TokenAuthHttpDownloader(HttpDownloader):
         This method provides the same return object type and documented in
         :meth:`~pulpcore.plugin.download.BaseDownloader._run`.
 
-        Ansible token reference:
-            https://github.com/ansible/ansible/blob/devel/lib/ansible/galaxy/token.py
-
         """
-        if not self.ansible_token:
+        if not self.token:
             # No Token
             return await super()._run(extra_data=extra_data)
-
-        if not self.ansible_auth_url:
-            # Galaxy Token
-            headers = {"Authorization": self.ansible_token}
-            return await self._run_with_additional_headers(headers)
         else:
             return await self._run_with_token_refresh_and_401_retry()
 
@@ -159,7 +151,7 @@ class TokenAuthHttpDownloader(HttpDownloader):
             form_payload = {
                 "grant_type": "refresh_token",
                 "client_id": "cloud-services",
-                "refresh_token": self.ansible_token,
+                "refresh_token": self.token,
             }
             url = self.ansible_auth_url
             async with self.session.post(url, data=form_payload, raise_for_status=True) as response:

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -150,6 +150,15 @@ class CollectionRemoteSerializer(RemoteSerializer):
                 if collection[2]:
                     _validate_url(collection[2])
 
+        if "token" in data and "auth_url" not in data:
+            raise serializers.ValidationError(
+                _("When specifying 'token' you must also specify 'auth_url'.")
+            )
+        if "auth_url" in data and "token" not in data:
+            raise serializers.ValidationError(
+                _("When specifying 'auth_url' you must also specify 'token'.")
+            )
+
         return data
 
     class Meta:

--- a/pulp_ansible/tests/functional/api/collection/test_remote.py
+++ b/pulp_ansible/tests/functional/api/collection/test_remote.py
@@ -1,0 +1,34 @@
+"""Tests related to CollectionRemote objects."""
+import unittest
+
+from pulpcore.client.pulp_ansible import RemotesCollectionApi
+from pulpcore.client.pulp_ansible.exceptions import ApiException
+
+from pulp_ansible.tests.functional.utils import gen_ansible_client, gen_ansible_remote
+from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+class CollectionRemoteCase(unittest.TestCase):
+    """Test CollectionRemote."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.client = gen_ansible_client()
+        cls.remote_collection_api = RemotesCollectionApi(cls.client)
+
+    def test_remote_with_url_only_is_allowed(self):
+        """Assert that a `CollectionRemote` with only a url can be created."""
+        body = gen_ansible_remote(url="https://example.com/")
+        remote = self.remote_collection_api.create(body)
+        self.addCleanup(self.remote_collection_api.delete, remote.pulp_href)
+
+    def test_token_requires_auth_url(self):
+        """Assert that a `CollectionRemote` with `token` and no `auth_url` can't be created."""
+        body = gen_ansible_remote(url="https://example.com/", token="this is a token string")
+        self.assertRaises(ApiException, self.remote_collection_api.create, body)
+
+    def test_auth_url_requires_token(self):
+        """Assert that a `CollectionRemote` with `auth_url` and no `token` can't be created."""
+        body = gen_ansible_remote(url="https://example.com/", auth_url="https://example.com")
+        self.assertRaises(ApiException, self.remote_collection_api.create, body)


### PR DESCRIPTION
When using either the `token` or `auth_url` attributes, ensure the user
is using both.

closes #7802