### PR TITLE
Moves doc site to docs.pulpproject.org

### DIFF
--- a/CHANGES/7926.doc
+++ b/CHANGES/7926.doc
@@ -1,0 +1,1 @@
+Move official docs site to https://docs.pulpproject.org/pulp_ansible/.

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ pulp_ansible
 
 A Pulp plugin to support hosting ``Role`` and ``Collection`` Ansible content.
 
-For more information, please see the `documentation <https://pulp-ansible.readthedocs.io/en/latest/>`_.
+For more information, please see the `documentation <https://docs.pulpproject.org/pulp_ansible/>`_.
 
 
 Collection Support


### PR DESCRIPTION
The new site link is https://docs.pulpproject.org/pulp_ansible/

closes #7926