### PR TITLE
Allow updating auth_url on CollectionRemote when token is already set

### DIFF
--- a/CHANGES/7957.bugfix
+++ b/CHANGES/7957.bugfix
@@ -1,0 +1,1 @@
+Allow updating ``auth_url`` on CollectionRemote when ``token``is already set

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -151,7 +151,8 @@ class CollectionRemoteSerializer(RemoteSerializer):
                 if collection[2]:
                     _validate_url(collection[2])
 
-        if "auth_url" in data and "token" not in data:
+        has_token = "token" in data or getattr(self.instance, "token", False)
+        if data.get("auth_url") and not has_token:
             raise serializers.ValidationError(
                 _("When specifying 'auth_url' you must also specify 'token'.")
             )

--- a/pulp_ansible/tests/functional/api/collection/test_remote.py
+++ b/pulp_ansible/tests/functional/api/collection/test_remote.py
@@ -1,5 +1,6 @@
 """Tests related to CollectionRemote objects."""
 from pulpcore.client.pulp_ansible.exceptions import ApiException
+from pulp_smash.pulp3.bindings import monitor_task
 
 from pulp_ansible.tests.functional.utils import gen_ansible_remote, TestCaseUsingBindings
 from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -18,6 +19,22 @@ class CollectionRemoteCase(TestCaseUsingBindings):
         """Assert that a `CollectionRemote` with `token` and no `auth_url` can be created."""
         body = gen_ansible_remote(url="https://example.com/", token="this is a token string")
         remote = self.remote_collection_api.create(body)
+        self.addCleanup(self.remote_collection_api.delete, remote.pulp_href)
+
+    def test_update_auth_url(self):
+        """Assert that a `CollectionRemote` with `token` and no `auth_url` can be created."""
+        body = gen_ansible_remote(
+            url="https://example.com/",
+            token="this is a token string",
+            auth_url="https://example.com",
+        )
+        remote = self.remote_collection_api.create(body)
+        response = self.remote_collection_api.partial_update(remote.pulp_href, {"auth_url": None})
+        monitor_task(response.task)
+        response = self.remote_collection_api.partial_update(
+            remote.pulp_href, {"auth_url": "https://example.com"}
+        )
+        monitor_task(response.task)
         self.addCleanup(self.remote_collection_api.delete, remote.pulp_href)
 
     def test_auth_url_requires_token(self):


### PR DESCRIPTION
https://pulp.plan.io/issues/7957
closes #7957