### PR TITLE
Fix OpenAPI schema for galaxy v3 pagination

### DIFF
--- a/pulp_ansible/app/galaxy/v3/pagination.py
+++ b/pulp_ansible/app/galaxy/v3/pagination.py
@@ -73,27 +73,32 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination):
             "type": "object",
             "properties": {
                 "meta": {
-                    "count": {
-                        "type": "integer",
-                        "example": 123,
-                    },
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer",
+                            "example": 123,
+                        },
                 },
                 "links": {
-                    "first": {
-                        "type": "string",
-                        "nullable": True,
-                    },
-                    "previous": {
-                        "type": "string",
-                        "nullable": True,
-                    },
-                    "next": {
-                        "type": "string",
-                        "nullable": True,
-                    },
-                    "last": {
-                        "type": "string",
-                        "nullable": True,
+                    "type": "object",
+                    "properties": {
+                        "first": {
+                            "type": "string",
+                            "nullable": True,
+                        },
+                        "previous": {
+                            "type": "string",
+                            "nullable": True,
+                        },
+                        "next": {
+                            "type": "string",
+                            "nullable": True,
+                        },
+                        "last": {
+                            "type": "string",
+                            "nullable": True,
+                        },
                     },
                 },
                 "data": schema,


### PR DESCRIPTION
The generated schema was failing validation in the
list responses for CollectionVersionViewSet.

The 'type' of the 'meta' field wasn't set, so 'count'
wasn't a valid property in the 'meta' field.

Ditto for the 'links' section.

No-Issue