### PR TITLE
Building changelog for 0.5.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,23 @@ Misc
 ----
 
 
+0.5.6 (2021-01-12)
+==================
+
+Bugfixes
+--------
+
+- Fixed v3 schema pagination to match OpenAPI standard
+  `#8037 <https://pulp.plan.io/issues/8037>`_
+- Fix collection version comparison on re-syncs
+  `#8039 <https://pulp.plan.io/issues/8039>`_
+- Enable proxy on token refresh requests
+  `#8051 <https://pulp.plan.io/issues/8051>`_
+
+
+----
+
+
 0.5.5 (2020-12-11)
 ==================
 

--- a/CHANGES/8037.bugfix
+++ b/CHANGES/8037.bugfix
@@ -1,1 +1,0 @@
-Fixed v3 schema pagination to match OpenAPI standard

--- a/CHANGES/8039.bugfix
+++ b/CHANGES/8039.bugfix
@@ -1,1 +1,0 @@
-Fix collection version comparison on re-syncs

--- a/CHANGES/8051.bugfix
+++ b/CHANGES/8051.bugfix
@@ -1,1 +1,0 @@
-Enable proxy on token refresh requests


### PR DESCRIPTION
[noissue]

(cherry picked from commit cb7199c45ee3b289c32bea942db23ca14a202084)