### PR TITLE
Make collection namespace max_length consistent in models

### DIFF
--- a/CHANGES/8078.bugfix
+++ b/CHANGES/8078.bugfix
@@ -1,0 +1,1 @@
+Make collection namespace max_length consistent in models

--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -137,7 +137,7 @@ class CollectionVersion(Content):
     issues = models.CharField(default="", blank=True, max_length=2000, editable=False)
     license = psql_fields.ArrayField(models.CharField(max_length=32), default=list, editable=False)
     name = models.CharField(max_length=64, editable=False)
-    namespace = models.CharField(max_length=32, editable=False)
+    namespace = models.CharField(max_length=64, editable=False)
     repository = models.CharField(default="", blank=True, max_length=2000, editable=False)
     version = models.CharField(max_length=128, editable=False)
 


### PR DESCRIPTION
Make CollectionVersion.namespace max_length match Collection.namespace

https://pulp.plan.io/issues/8078
closes #8078