### PR TITLE
Create a new endpoint to return collection level dependencies

### DIFF
--- a/CHANGES/8132.feature
+++ b/CHANGES/8132.feature
@@ -1,0 +1,1 @@
+Create a new ``collections/ns/name/versions/version/dependencies/``endpoint that returns collection level dependencies.

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -99,6 +99,29 @@ class CollectionVersionListSerializer(serializers.ModelSerializer):
         )
 
 
+class CollectionVersionDependencySerializer(CollectionSerializer):
+    """A serializer for returning a CollectionVersion's dependencies."""
+
+    dependencies = serializers.JSONField()
+
+    class Meta:
+        fields = ("version", "dependencies")
+        model = models.CollectionVersion
+
+    def get_href(self, obj):
+        """
+        Get href.
+        """
+        kwargs = {
+            "path": self.context["path"],
+            "namespace": obj.namespace,
+            "name": obj.name,
+            "version": obj.version,
+        }
+
+        return self._get_href("collection-version-dependency", **kwargs)
+
+
 class ArtifactRefSerializer(serializers.Serializer):
     """A serializer for an Artifact reference."""
 

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -68,6 +68,11 @@ v3_urls = [
         name="collection-versions-detail-docs",
     ),
     path(
+        "collections/<str:namespace>/<str:name>/versions/<str:version>/dependencies/",
+        views_v3.CollectionVersionDependencyViewSet.as_view({"get": "retrieve"}),
+        name="collection-versions-detail-dependency",
+    ),
+    path(
         "imports/collections/<uuid:pk>/",
         views_v3.CollectionImportViewSet.as_view({"get": "retrieve"}),
         name="collection-imports-detail",


### PR DESCRIPTION
Create a new ``collections/ns/name/versions/version/dependencies/`` endpoint that returns collection level dependencies.

https://pulp.plan.io/issues/8132
closes #8132