### PR TITLE
Cherrypick to 0.5: Use DRF token when no auth_url is provided

### DIFF
--- a/CHANGES/8290.bugfix
+++ b/CHANGES/8290.bugfix
@@ -1,0 +1,1 @@
+Use DRF token when no ``auth_url`` is provided

--- a/pulp_ansible/app/downloaders.py
+++ b/pulp_ansible/app/downloaders.py
@@ -87,7 +87,8 @@ class TokenAuthHttpDownloader(HttpDownloader):
         if not self.token and not self.ansible_auth_url:
             return await super()._run(extra_data=extra_data)
         elif self.token and not self.ansible_auth_url:
-            headers = {"Authorization": "Bearer {token}".format(token=self.token)}
+            # https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication
+            headers = {"Authorization": "Token {token}".format(token=self.token)}
             return await self._run_with_additional_headers(headers)
         else:
             return await self._run_with_token_refresh_and_401_retry()


### PR DESCRIPTION
https://pulp.plan.io/issues/8290
closes #8290

(cherry picked from commit 002fab0bfd3eddf03d272182eaf7269590953a60)