### PR TITLE
Provide backend storage url to galaxy-importer on collection import

### DIFF
--- a/CHANGES/8486.feature
+++ b/CHANGES/8486.feature
@@ -1,0 +1,1 @@
+Provide backend storage url to galaxy-importer on collection import.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async_lru
-galaxy_importer
+galaxy_importer>=0.3.1
 jsonschema>=3.0
 packaging
 pulpcore>=3.10


### PR DESCRIPTION
Moves the setting of `ResponseContentDisposition` out of `galaxy-importer`, and allows for support of Azure backend as well as AWS, see [pulp issue 8486](https://pulp.plan.io/issues/8486).

This implementation replicates the logic found in [pulpcore _serve_content_artifact()](https://github.com/pulp/pulpcore/blob/8a77316d2d73dd31d6f47b964bf148a602da6a21/pulpcore/content/handler.py#L581), unsure if there is a good way to share this logic between pulpcore and a plugin.

fixes: #8486
https://pulp.plan.io/issues/8486