### PR TITLE
Replace Unpaginated endpoints with unified metadata for sync

### DIFF
--- a/CHANGES/8439.misc
+++ b/CHANGES/8439.misc
@@ -1,0 +1,1 @@
+Replaced Unpaginated endpoints with higher pagination limit

--- a/pulp_ansible/app/galaxy/v3/pagination.py
+++ b/pulp_ansible/app/galaxy/v3/pagination.py
@@ -121,3 +121,14 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination):
             self.display_page_controls = True
 
         return self.get_paginated_response(data)
+
+
+
+class OptimizedLimitOffsetPagination(LimitOffsetPagination):
+    """
+    Pagination for V3 optimized sync.
+
+    """
+
+    default_limit = 1000
+    max_limit = 10000

--- a/pulp_ansible/app/galaxy/v3/pagination.py
+++ b/pulp_ansible/app/galaxy/v3/pagination.py
@@ -123,7 +123,6 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination):
         return self.get_paginated_response(data)
 
 
-
 class OptimizedLimitOffsetPagination(LimitOffsetPagination):
     """
     Pagination for V3 optimized sync.

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -176,6 +176,7 @@ class MetadataCollectionVersionSerializer(CollectionVersionListSerializer):
     A serializer for Sync Metadata CollectionVersion.
     """
 
+    collection = CollectionRefSerializer(read_only=True)
     artifact = serializers.SerializerMethodField()
     download_url = serializers.SerializerMethodField()
 
@@ -186,6 +187,7 @@ class MetadataCollectionVersionSerializer(CollectionVersionListSerializer):
         model = models.CollectionVersion
         fields = CollectionVersionListSerializer.Meta.fields + (
             "artifact",
+            "collection",
             "download_url",
             "name",
             "namespace",

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -27,9 +27,9 @@ from pulp_ansible.app.galaxy.v3.serializers import (
     CollectionSerializer,
     CollectionVersionSerializer,
     CollectionVersionDocsSerializer,
-    CollectionVersionListSerializer, MetadataCollectionSerializer,
+    CollectionVersionListSerializer,
+    MetadataCollectionSerializer,
     RepoMetadataSerializer,
-    MetadataCollectionVersionSerializer,
 )
 from pulp_ansible.app.models import (
     AnsibleCollectionDeprecated,
@@ -46,7 +46,7 @@ from pulp_ansible.app.serializers import (
 from pulp_ansible.app.galaxy.mixins import UploadGalaxyCollectionMixin
 from pulp_ansible.app.galaxy.v3.pagination import (
     LimitOffsetPagination,
-    OptimizedLimitOffsetPagination
+    OptimizedLimitOffsetPagination,
 )
 from pulp_ansible.app.viewsets import CollectionVersionFilter
 

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -313,6 +313,14 @@ class MetadataCollectionViewSet(CollectionViewSet):
     pagination_class = OptimizedLimitOffsetPagination
     serializer_class = MetadataCollectionSerializer
 
+    def get_queryset(self):
+        """
+        Returns a Collections queryset for specified distribution.
+
+        and prefetches related versions.
+        """
+        return super().get_queryset().prefetch_related("versions")
+
 
 class CollectionUploadViewSet(
     ExceptionHandlerMixin, viewsets.GenericViewSet, UploadGalaxyCollectionMixin

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -581,11 +581,11 @@ class CollectionSyncFirstStage(Stage):
             collection_list_url = f"{collection_endpoint}?limit={page_size}&offset={offset}"
         return self.remote.get_downloader(url=collection_list_url)
 
-    async def _download_unpaginated_metadata(self):
+    async def _download_optimized_metadata(self):
         root_endpoint, api_version = await self._get_root_api(self.remote.url)
         self._api_version = api_version
         if api_version > 2:
-            collection_endpoint = f"{root_endpoint}/collections/all/"
+            collection_endpoint = f"{root_endpoint}/collections/metadata/"
             downloader = self.remote.get_downloader(
                 url=collection_endpoint, silence_errors_for_response_status_codes={404}
             )
@@ -741,7 +741,7 @@ class CollectionSyncFirstStage(Stage):
         tasks = []
         loop = asyncio.get_event_loop()
 
-        await self._download_unpaginated_metadata()
+        await self._download_optimized_metadata()
 
         if self.collection_info:
             for requirement_entry in self.collection_info:

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -74,14 +74,9 @@ v3_urls = [
         name="collection-imports-detail",
     ),
     path(
-        "collections/all/",
-        views_v3.UnpaginatedCollectionViewSet.as_view({"get": "list"}),
+        "collections/metadata/",
+        views_v3.MetadataCollectionViewSet.as_view({"get": "list"}),
         name="metadata-collection-list",
-    ),
-    path(
-        "collection_versions/all/",
-        views_v3.UnpaginatedCollectionVersionViewSet.as_view({"get": "list"}),
-        name="metadata-collection-versions-list",
     ),
 ]
 


### PR DESCRIPTION
- Remove Unpaginated /all/ endpoints
- Adds a Paginator with bigger limit
- Adds /collection/metadata/ endpoint with unified metadata for
  collection and its versions
- Changed sync to use this `optimized` downloader using 1000 limit per
  pagination


output example: https://gist.github.com/rochacbruno/df9c1c3e2653d1e9592cd8f650de2239

this is a temporary solution to be replaced by #553 which will pack the collections/metadata/ in a publication.
related to: https://github.com/ansible/galaxy_ng/pull/726

fixes: #8439
