### PR TITLE
/collection_versions/all/ endpoint is now streamed

### DIFF
--- a/CHANGES/8439.bugfix
+++ b/CHANGES/8439.bugfix
@@ -1,0 +1,1 @@
+`/collection_versions/all/` endpoint is now streamed to alleviate timeout issues


### PR DESCRIPTION
This is super fast I think. Potentially fast enough to rethink when or if we will need publications.