### PR TITLE
Optimize unpaginated collection_versions endpoint query

### DIFF
--- a/CHANGES/8746.bugfix
+++ b/CHANGES/8746.bugfix
@@ -1,0 +1,1 @@
+Optimized unpaginated collection_versions endpoint

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.reverse import reverse
 from rest_framework import serializers, relations
 
 from pulp_ansible.app import models
+from pulpcore.plugin.models import ContentArtifact
 
 
 class CollectionSerializer(serializers.ModelSerializer):
@@ -198,7 +199,8 @@ class UnpaginatedCollectionVersionSerializer(CollectionVersionListSerializer):
         """
         Get atrifact summary.
         """
-        return ArtifactRefSerializer(obj.contentartifact_set.get()).data
+        content_artifact = ContentArtifact.objects.select_related("artifact").filter(content=obj)
+        return ArtifactRefSerializer(content_artifact.get()).data
 
     def get_download_url(self, obj) -> str:
         """
@@ -206,7 +208,7 @@ class UnpaginatedCollectionVersionSerializer(CollectionVersionListSerializer):
         """
         host = settings.ANSIBLE_CONTENT_HOSTNAME.strip("/")
         distro_base_path = self.context["path"]
-        filename_path = obj.contentartifact_set.get().relative_path.lstrip("/")
+        filename_path = obj.relative_path.lstrip("/")
         download_url = f"{host}/{distro_base_path}/{filename_path}"
         return download_url
 

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -434,24 +434,15 @@ class UnpaginatedCollectionVersionViewSet(CollectionVersionViewSet):
         """
         distro_content = self._distro_content
 
-        return CollectionVersion.objects.select_related("content_ptr__contentartifact").filter(
-            pk__in=distro_content
-        )
+        return CollectionVersion.objects.select_related().filter(pk__in=distro_content)
 
     def list(self, request, *args, **kwargs):
         """
         Returns paginated CollectionVersions list.
         """
-        queryset = self.filter_queryset(self.get_queryset())
-        queryset = sorted(
-            queryset, key=lambda obj: semantic_version.Version(obj.version), reverse=True
-        )
+        queryset = self.get_queryset().iterator()
 
         context = self.get_serializer_context()
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer(page, many=True, context=context)
-            return self.get_paginated_response(serializer.data)
 
         serializer = self.get_serializer(queryset, many=True, context=context)
         return Response(serializer.data)


### PR DESCRIPTION
[noissue]

This should reduce the amount of database queries 5x. So now the amount of queries for this endpoint is n + 4 where n is the number of collectionversions.  I'm not sure if I can remove the final n queries to make this constant since they are for the tags which are a many-to-many relation.