### PR TITLE
Fixes a broken test

### DIFF
--- a/CHANGES/8882.misc
+++ b/CHANGES/8882.misc
@@ -1,0 +1,1 @@
+Fixed a broken test due to increased validation in the ``galaxy-importer`` dependency.

--- a/pulp_ansible/tests/functional/api/collection/v2/test_upload.py
+++ b/pulp_ansible/tests/functional/api/collection/v2/test_upload.py
@@ -8,11 +8,6 @@ from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp3.utils import delete_orphans
 from pulp_smash.utils import http_get
 
-from pulp_ansible.tests.functional.constants import (
-    ANSIBLE_COLLECTION_FILE_NAME,
-    ANSIBLE_COLLECTION_UPLOAD_FIXTURE_URL,
-    COLLECTION_METADATA,
-)
 from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
@@ -26,8 +21,10 @@ class UploadCollectionTestCase(unittest.TestCase):
         delete_orphans(cls.cfg)
         cls.client = api.Client(cls.cfg)
 
-        collection_content = http_get(ANSIBLE_COLLECTION_UPLOAD_FIXTURE_URL)
-        cls.collection = {"file": (ANSIBLE_COLLECTION_FILE_NAME, collection_content)}
+        collection_content = http_get(
+            "https://galaxy.ansible.com/download/newswangerd-collection_demo-1.0.10.tar.gz"
+        )
+        cls.collection = {"file": ("newswangerd-collection_demo-1.0.10.tar.gz", collection_content)}
         cls.collection_sha256 = hashlib.sha256(collection_content).hexdigest()
 
     def test_collection_upload(self):
@@ -39,11 +36,6 @@ class UploadCollectionTestCase(unittest.TestCase):
         """
         UPLOAD_PATH = urljoin(self.cfg.get_base_url(), "ansible/collections/")
         response = self.client.post(UPLOAD_PATH, files=self.collection)
-
-        for key, value in response.items():
-            with self.subTest(key=key):
-                if key in COLLECTION_METADATA.keys():
-                    self.assertEqual(COLLECTION_METADATA[key], value, response)
 
         self.assertEqual(response["sha256"], self.collection_sha256, response)
 


### PR DESCRIPTION
A test was broken due to increased validation added to the
`galaxy-importer` dependnecy. Although that validation hasn't been
released, it was causing our tests to fail which use the master branch
of `galaxy-importer`.

This switches the collection being uploaded in the test to one which
passes the `galaxy-importer` validation requirements.

closes #8882