### PR TITLE
Drop support for Python 3.6 and 3.7

### DIFF
--- a/.ci/ansible/Containerfile.j2
+++ b/.ci/ansible/Containerfile.j2
@@ -23,7 +23,7 @@ RUN pip3 install \
 
 RUN mkdir -p /etc/nginx/pulp/
 {% for item in plugins %}
-RUN ln /usr/local/lib/python3.6/site-packages/{{ item.name }}/app/webserver_snippets/nginx.conf /etc/nginx/pulp/{{ item.name }}.conf || true
+RUN ln /usr/local/lib/python3.8/site-packages/{{ item.name }}/app/webserver_snippets/nginx.conf /etc/nginx/pulp/{{ item.name }}.conf || true
 {% endfor %}
 
 ENTRYPOINT ["/init"]

--- a/.github/workflows/scripts/script.sh
+++ b/.github/workflows/scripts/script.sh
@@ -93,7 +93,7 @@ echo "Checking for uncommitted migrations..."
 cmd_prefix bash -c "django-admin makemigrations --check --dry-run"
 
 # Run unit tests.
-cmd_prefix bash -c "PULP_DATABASES__default__USER=postgres django-admin test --noinput /usr/local/lib/python3.6/site-packages/pulp_ansible/tests/unit/"
+cmd_prefix bash -c "PULP_DATABASES__default__USER=postgres django-admin test --noinput /usr/local/lib/python3.8/site-packages/pulp_ansible/tests/unit/"
 
 # Run functional tests
 export PYTHONPATH=$REPO_ROOT:$REPO_ROOT/../pulpcore${PYTHONPATH:+:${PYTHONPATH}}

--- a/CHANGES/9034.removal
+++ b/CHANGES/9034.removal
@@ -1,0 +1,1 @@
+Dropped support for Python 3.6 and 3.7. pulp_ansible now supports Python 3.8+.

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
         "Framework :: Django",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ),
     entry_points={"pulpcore.plugin": ["pulp_ansible = pulp_ansible:default_app_config"]},
 )


### PR DESCRIPTION
This is waiting on pulp/pulp-oci-images#100. I'm waiting for more feedback before I merge.

fixes #9034