### PR TITLE
Use proxy auth from the Remote config

### DIFF
--- a/CHANGES/9075.bugfix
+++ b/CHANGES/9075.bugfix
@@ -1,0 +1,1 @@
+Use proxy auth credentials of a Remote when syncing content.

--- a/pulp_ansible/app/downloaders.py
+++ b/pulp_ansible/app/downloaders.py
@@ -131,7 +131,9 @@ class TokenAuthHttpDownloader(HttpDownloader):
         """
         if self.download_throttler:
             await self.download_throttler.acquire()
-        async with self.session.get(self.url, headers=headers, proxy=self.proxy) as response:
+        async with self.session.get(
+            self.url, headers=headers, proxy=self.proxy, proxy_auth=self.proxy_auth, auth=self.auth
+        ) as response:
             self.raise_for_status(response)
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
https://pulp.plan.io/issues/9075
closes #9075