### PR TITLE
Backport fix for optimized mirror syncs removing repository content

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -158,7 +158,7 @@ pip install docker netaddr boto3 ansible
 
 for i in {1..3}
 do
-  ansible-galaxy collection install amazon.aws && s=0 && break || s=$? && sleep 3
+  ansible-galaxy collection install "amazon.aws:1.5.0" && s=0 && break || s=$? && sleep 3
 done
 if [[ $s -gt 0 ]]
 then

--- a/CHANGES/9480.bugfix
+++ b/CHANGES/9480.bugfix
@@ -1,0 +1,2 @@
+Fixed optimized mirror syncs erroneously removing all content in the repository.
+(backported from #9476)

--- a/pulp_ansible/tests/functional/api/collection/test_crud_collection_versions.py
+++ b/pulp_ansible/tests/functional/api/collection/test_crud_collection_versions.py
@@ -96,7 +96,7 @@ class ContentUnitTestCase(unittest.TestCase):
         """Clean class-wide variable."""
         delete_orphans()
 
-    def upload_collection(self, namespace="pulp", name="pulp_installer", version="3.14.0"):
+    def upload_collection(self, namespace="pulp", name="squeezer", version="0.0.9"):
         """Upload collection."""
         url = f"https://galaxy.ansible.com/download/{namespace}-{name}-{version}.tar.gz"
         collection_content = http_get(url)
@@ -108,7 +108,7 @@ class ContentUnitTestCase(unittest.TestCase):
 
     def test_01_create_content_unit(self):
         """Create content unit."""
-        attrs = dict(namespace="pulp", name="pulp_installer", version="3.14.0")
+        attrs = dict(namespace="pulp", name="squeezer", version="0.0.9")
         response = self.upload_collection(**attrs)
         created_resources = monitor_task(response.task).created_resources
         content_unit = self.cv_content_api.read(created_resources[0])
@@ -174,7 +174,7 @@ class ContentUnitTestCase(unittest.TestCase):
     @skip_if(bool, "content_unit", False)
     def test_05_duplicate_raise_error(self):
         """Attempt to create duplicate collection."""
-        attrs = dict(namespace="pulp", name="pulp_installer", version="3.14.0")
+        attrs = dict(namespace="pulp", name="squeezer", version="0.0.9")
         with self.assertRaises(ApiException) as ctx:
             self.upload_collection(**attrs)
         self.assertIn(

--- a/pulp_ansible/tests/functional/api/collection/v3/test_deprecation.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_deprecation.py
@@ -14,7 +14,7 @@ class DeprecationTestCase(TestCaseUsingBindings, SyncHelpersMixin):
         """Test sync  sync."""
         # Sync down two collections into a repo
         requirements = (
-            "collections:\n  - name: testing.k8s_demo_collection\n  - name: pulp.pulp_installer"
+            "collections:\n  - name: testing.k8s_demo_collection\n  - name: pulp.squeezer"
         )
 
         body = gen_ansible_remote(
@@ -60,7 +60,7 @@ class DeprecationTestCase(TestCaseUsingBindings, SyncHelpersMixin):
 
         # Update the requirements to sync down both collections this time
         requirements = (
-            "collections:\n  - name: testing.k8s_demo_collection\n  - name: pulp.pulp_installer"
+            "collections:\n  - name: testing.k8s_demo_collection\n  - name: pulp.squeezer"
         )
         self.remote_collection_api.partial_update(
             second_remote.pulp_href, {"requirements_file": requirements}

--- a/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
@@ -32,7 +32,7 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
         """Test Collections V3 endpoint field: ``updated_at``."""
         body = gen_ansible_remote(
             url="https://galaxy.ansible.com",
-            requirements_file="collections:\n  - pulp.pulp_installer",
+            requirements_file="collections:\n  - pulp.squeezer",
             sync_dependencies=False,
         )
         remote = self.remote_collection_api.create(body)
@@ -46,9 +46,9 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
         original_highest_version = collections.data[0].highest_version["version"]
         original_updated_at = collections.data[0].updated_at
 
-        versions = self.collections_versions_api.list(version="3.6.4")
+        versions = self.collections_versions_api.list(version="0.0.7")
         original_total_versions = self.collections_versions_v3api.list(
-            "pulp_installer", "pulp", distribution.base_path
+            "squeezer", "pulp", distribution.base_path
         ).meta.count
 
         data = {"remove_content_units": [versions.results[0].pulp_href]}
@@ -60,7 +60,7 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
         updated_at = collections.data[0].updated_at
 
         total_versions = self.collections_versions_v3api.list(
-            "pulp_installer", "pulp", distribution.base_path
+            "squeezer", "pulp", distribution.base_path
         ).meta.count
 
         self.assertEqual(highest_version, original_highest_version)


### PR DESCRIPTION
backports: #9476

fixes: #9480
https://pulp.plan.io/issues/9480

Had to create this backport manually. The async changes for 0.10 to be compatible with Django 3 have greatly changed the collection sync code. Might become a big pain to support 0.9.0 if lots of task issues are found.