### PR TITLE
Updates SyncHelpersMixin with GitRemote API client

### DIFF
--- a/pulp_ansible/tests/functional/api/collection/v3/test_sync.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_sync.py
@@ -118,7 +118,7 @@ class SyncCollectionsFromPulpServerTestCase(TestCaseUsingBindings, SyncHelpersMi
         second_remote = self.remote_collection_api.create(second_body)
         self.addCleanup(self.remote_collection_api.delete, second_remote.pulp_href)
 
-        second_repo = self._create_repo_and_sync_with_remote(second_remote)
+        second_repo = self._create_repo_with_attached_remote_and_sync(second_remote)
 
         second_content = self.cv_api.list(repository_version=f"{second_repo.pulp_href}versions/1/")
         self.assertGreaterEqual(len(second_content.results), 1)
@@ -146,7 +146,7 @@ class SyncCollectionsFromPulpServerTestCase(TestCaseUsingBindings, SyncHelpersMi
         second_remote = self.remote_collection_api.create(second_body)
         self.addCleanup(self.remote_collection_api.delete, second_remote.pulp_href)
 
-        second_repo = self._create_repo_and_sync_with_remote(second_remote)
+        second_repo = self._create_repo_with_attached_remote_and_sync(second_remote)
 
         second_content = self.cv_api.list(repository_version=f"{second_repo.pulp_href}versions/1/")
         self.assertGreaterEqual(len(second_content.results), 1)
@@ -175,7 +175,7 @@ class SyncCollectionsFromPulpServerTestCase(TestCaseUsingBindings, SyncHelpersMi
         remote = self.remote_collection_api.create(body)
         self.addCleanup(self.remote_collection_api.delete, remote.pulp_href)
 
-        repo = self._create_repo_and_sync_with_remote(remote)
+        repo = self._create_repo_with_attached_remote_and_sync(remote)
         self.assertIsNotNone(repo.last_synced_metadata_time)
 
         response = self.remote_collection_api.partial_update(

--- a/pulp_ansible/tests/functional/api/git/test_crud_remotes.py
+++ b/pulp_ansible/tests/functional/api/git/test_crud_remotes.py
@@ -1,34 +1,29 @@
 # coding=utf-8
 """Tests that CRUD remotes."""
-from pulpcore.client.pulp_ansible import RemotesGitApi
+from pulp_smash.pulp3.bindings import monitor_task
 
-from pulp_smash.pulp3.bindings import monitor_task, PulpTestCase
-
-from pulp_ansible.tests.functional.utils import gen_ansible_client, gen_ansible_remote
+from pulp_ansible.tests.functional.utils import (
+    gen_ansible_remote,
+    TestCaseUsingBindings,
+)
 from pulp_ansible.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
 
-class CRUDAnsibleGitRemotesTestCase(PulpTestCase):
+class CRUDAnsibleGitRemotesTestCase(TestCaseUsingBindings):
     """CRUD Ansible Git remotes."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create class-wide variables."""
-        cls.client = gen_ansible_client()
-        cls.remote_ansible_git_api = RemotesGitApi(cls.client)
 
     def test_01_crud_remote(self):
         """Create, Read, Partial Update, and Delete an Ansible Git remote."""
         body = gen_ansible_remote(url="https://github.com/geerlingguy/ansible-role-adminer.git")
-        remote = self.remote_ansible_git_api.create(body)
-        self.addCleanup(self.remote_ansible_git_api.delete, remote.pulp_href)
-        remote = self.remote_ansible_git_api.read(remote.pulp_href)
+        remote = self.remote_git_api.create(body)
+        self.addCleanup(self.remote_git_api.delete, remote.pulp_href)
+        remote = self.remote_git_api.read(remote.pulp_href)
         for k, v in body.items():
             self.assertEquals(body[k], getattr(remote, k))
         update_body = {"url": "https://github.com/geerlingguy/ansible-role-ansible.git"}
-        remote_update = self.remote_ansible_git_api.partial_update(remote.pulp_href, update_body)
+        remote_update = self.remote_git_api.partial_update(remote.pulp_href, update_body)
         monitor_task(remote_update.task)
-        remote = self.remote_ansible_git_api.read(remote.pulp_href)
+        remote = self.remote_git_api.read(remote.pulp_href)
         self.assertEqual(remote.url, update_body["url"])
         self.assertEqual(remote.metadata_only, False)
         with self.assertRaises(AttributeError):
@@ -39,7 +34,7 @@ class CRUDAnsibleGitRemotesTestCase(PulpTestCase):
         body = gen_ansible_remote(
             url="https://github.com/geerlingguy/ansible-role-adminer.git", metadata_only=True
         )
-        remote = self.remote_ansible_git_api.create(body)
-        self.addCleanup(self.remote_ansible_git_api.delete, remote.pulp_href)
+        remote = self.remote_git_api.create(body)
+        self.addCleanup(self.remote_git_api.delete, remote.pulp_href)
         for k, v in body.items():
             self.assertEqual(body[k], getattr(remote, k))

--- a/pulp_ansible/tests/functional/utils.py
+++ b/pulp_ansible/tests/functional/utils.py
@@ -37,6 +37,7 @@ from pulpcore.client.pulp_ansible import (
     PulpAnsibleApiV3CollectionsVersionsApi,
     RepositoriesAnsibleApi,
     RemotesCollectionApi,
+    RemotesGitApi,
     RemotesRoleApi,
     AnsibleRepositorySyncURL,
 )
@@ -148,6 +149,7 @@ class TestCaseUsingBindings(PulpTestCase):
         cls.client = gen_ansible_client()
         cls.repo_api = RepositoriesAnsibleApi(cls.client)
         cls.remote_collection_api = RemotesCollectionApi(cls.client)
+        cls.remote_git_api = RemotesGitApi(cls.client)
         cls.remote_role_api = RemotesRoleApi(cls.client)
         cls.distributions_api = DistributionsAnsibleApi(cls.client)
         cls.cv_api = ContentCollectionVersionsApi(cls.client)
@@ -174,7 +176,7 @@ class SyncHelpersMixin:
             repository: The created repository object to be asserted to.
         """
         # Create the repository.
-        repo = self.repo_api.create(gen_repo(remote=remote.pulp_href, **repo_kwargs))
+        repo = self.repo_api.create(gen_repo(**repo_kwargs))
         self.addCleanup(self.repo_api.delete, repo.pulp_href)
         return self._sync_repo(repo, remote=remote.pulp_href)
 


### PR DESCRIPTION
This also fixes _create_repo_and_sync_with_remote() in SyncHelpersMixin.

[noissue]