### PR TITLE
fix owner username case in galaxy view. same as on galaxy.ansible.com

### DIFF
--- a/CHANGES/9534.bugfix
+++ b/CHANGES/9534.bugfix
@@ -1,0 +1,1 @@
+* Case-insensitive search for the `owner__username` and role `name` fields in the pulp_ansible role view (same as on galaxy.ansible.com).

--- a/pulp_ansible/app/galaxy/views.py
+++ b/pulp_ansible/app/galaxy/views.py
@@ -64,10 +64,10 @@ class RoleList(generics.ListAPIView):
 
         namespace = self.request.query_params.get("owner__username", None)
         if namespace:
-            roles = roles.filter(namespace=namespace)
+            roles = roles.filter(namespace__iexact=namespace)
         name = self.request.query_params.get("name", None)
         if name:
-            roles = roles.filter(name=name)
+            roles = roles.filter(name__iexact=name)
 
         return roles
 


### PR DESCRIPTION
The galaxy.ansible.com API uses case-insensitive fields for the `owner` `username` and role `name`. The Ansible Galaxy Hub source code: https://github.com/ansible/galaxy/blob/e0e4b909171ddc6ca40f0ef2f7d4dce5680777ce/galaxy/api/views/roles.py#L50

But `pulp` uses`namespace=namespace`. It causes the error on case-sensitive repositories. Example

* https://galaxy.ansible.com/api/v1/roles/?owner__username=Oefenweb
* https://galaxy.ansible.com/api/v1/roles/?owner__username=oefenweb

Galaxy Ansible returns the same result. But pulp isn't.

So we can't install roles like this using regular `ansible-galaxy install oefenweb.postfix` command with the Pulp repo.

This patch solves the issue. fixes #9534