### PR TITLE
Fix functional tests with roles

### DIFF
--- a/pulp_ansible/tests/functional/constants.py
+++ b/pulp_ansible/tests/functional/constants.py
@@ -96,6 +96,8 @@ TABLES_TO_KEEP = (
     # not to be doomed by the lack of permissions
     "auth_permission",
     "core_accesspolicy",
+    "core_role",
+    "core_role_permissions",
     # 'auth_permission' references it, so it should not be truncated
     "django_content_type",
     # not to freak out the tasking system


### PR DESCRIPTION
Functional tests truncated too many tables. Especially roles and role
permissions must not be wiped for pulp to function properly.

[noissue]