### PR TITLE
Enables Collection Remote to sync content initially synced by Git Remote

### DIFF
--- a/CHANGES/778.feature
+++ b/CHANGES/778.feature
@@ -1,0 +1,1 @@
+Enabled Collection Remote to sync content that was initially synced using Git Remote.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -63,9 +63,81 @@ from pulp_ansible.app.tasks.utils import (
     parse_collections_requirements_file,
     RequirementsFileEntry,
 )
+from asgiref.sync import sync_to_async
+
+from django.db.utils import IntegrityError
+from galaxy_importer.collection import sync_collection
+from git import GitCommandError, Repo
+
+
+from uuid import uuid4
 
 
 log = logging.getLogger(__name__)
+
+
+async def declarative_content_from_git_repo(remote, url, git_ref=None, metadata_only=False):
+    """Returns a DeclarativeContent for the Collection in a Git repository."""
+    if git_ref:
+        try:
+            gitrepo = Repo.clone_from(url, uuid4(), depth=1, branch=git_ref)
+        except GitCommandError:
+            gitrepo = Repo.clone_from(url, uuid4())
+            gitrepo.git.checkout(git_ref)
+    else:
+        gitrepo = Repo.clone_from(url, uuid4(), depth=1)
+    commit_sha = gitrepo.head.commit.hexsha
+    metadata, artifact_path = sync_collection(gitrepo.working_dir, ".")
+    if not metadata_only:
+        artifact = Artifact.init_and_validate(artifact_path)
+        try:
+            await sync_to_async(artifact.save)()
+        except IntegrityError:
+            artifact = Artifact.objects.get(sha256=artifact.sha256)
+        metadata["artifact_url"] = reverse("artifacts-detail", args=[artifact.pk])
+        metadata["artifact"] = artifact
+    else:
+        metadata["artifact"] = None
+        metadata["artifact_url"] = None
+    metadata["remote_artifact_url"] = "{}/commit/{}".format(url.rstrip("/"), commit_sha)
+
+    artifact = metadata["artifact"]
+    try:
+        collection_version = await sync_to_async(create_collection_from_importer)(
+            metadata, metadata_only=metadata_only
+        )
+        await sync_to_async(ContentArtifact.objects.get_or_create)(
+            artifact=artifact,
+            content=collection_version,
+            relative_path=collection_version.relative_path,
+        )
+    except ValidationError as e:
+        if e.args[0]["non_field_errors"][0].code == "unique":
+            namespace = metadata["metadata"]["namespace"]
+            name = metadata["metadata"]["name"]
+            version = metadata["metadata"]["version"]
+        else:
+            raise e
+        collection_version = await sync_to_async(CollectionVersion.objects.get)(
+            namespace=namespace, name=name, version=version
+        )
+    if artifact is None:
+        artifact = Artifact()
+    d_artifact = DeclarativeArtifact(
+        artifact=artifact,
+        url=metadata["remote_artifact_url"],
+        relative_path=collection_version.relative_path,
+        remote=remote,
+        deferred_download=metadata_only,
+    )
+
+    # TODO: docs blob support??
+
+    d_content = DeclarativeContent(
+        content=collection_version,
+        d_artifacts=[d_artifact],
+    )
+    return d_content
 
 
 def update_collection_remote(remote_pk, *args, **kwargs):
@@ -514,7 +586,6 @@ class CollectionSyncFirstStage(Stage):
             setattr(collection_version, attr_name, attr_value)
 
         artifact = metadata["artifact"]
-
         d_artifact = DeclarativeArtifact(
             artifact=Artifact(sha256=artifact["sha256"], size=artifact["size"]),
             url=url,
@@ -533,6 +604,12 @@ class CollectionSyncFirstStage(Stage):
             extra_data=extra_data,
         )
         await self.parsing_metadata_progress_bar.aincrement()
+        await self.put(d_content)
+
+    async def _add_collection_version_from_git(self, url, gitref, metadata_only):
+        d_content = await declarative_content_from_git_repo(
+            self.remote, url, gitref, metadata_only=False
+        )
         await self.put(d_content)
 
     def _collection_versions_list_downloader(
@@ -610,17 +687,29 @@ class CollectionSyncFirstStage(Stage):
             await self.put(d_content)
 
         all_versions_of_collection = self._unpaginated_collection_version_metadata[namespace][name]
-
         for col_version_metadata in all_versions_of_collection:
             if col_version_metadata["version"] in requirement:
-                collection_version_url = urljoin(self.remote.url, f"{col_version_metadata['href']}")
-                tasks.append(
-                    loop.create_task(
-                        self._add_collection_version(
-                            self._api_version, collection_version_url, col_version_metadata
+                if "git_url" in col_version_metadata and col_version_metadata["git_url"]:
+                    tasks.append(
+                        loop.create_task(
+                            self._add_collection_version_from_git(
+                                col_version_metadata["git_url"],
+                                col_version_metadata["git_commit_sha"],
+                                False,
+                            )
                         )
                     )
-                )
+                else:
+                    collection_version_url = urljoin(
+                        self.remote.url, f"{col_version_metadata['href']}"
+                    )
+                    tasks.append(
+                        loop.create_task(
+                            self._add_collection_version(
+                                self._api_version, collection_version_url, col_version_metadata
+                            )
+                        )
+                    )
         await asyncio.gather(*tasks)
 
     async def _fetch_collection_metadata(self, requirements_entry):

--- a/pulp_ansible/app/tasks/git.py
+++ b/pulp_ansible/app/tasks/git.py
@@ -1,22 +1,15 @@
 import logging
 
-from asgiref.sync import sync_to_async
-from django.urls import reverse
-from django.db.utils import IntegrityError
-from galaxy_importer.collection import sync_collection
 from gettext import gettext as _
-from git import GitCommandError, Repo
-from rest_framework.exceptions import ValidationError
 
-from pulpcore.plugin.models import Artifact, ContentArtifact, ProgressReport
+
+from pulpcore.plugin.models import ProgressReport
 from pulpcore.plugin.stages import (
-    DeclarativeArtifact,
-    DeclarativeContent,
     DeclarativeVersion,
     Stage,
 )
-from pulp_ansible.app.models import AnsibleRepository, CollectionVersion, GitRemote
-from pulp_ansible.app.tasks.collections import create_collection_from_importer
+from pulp_ansible.app.models import AnsibleRepository, GitRemote
+from pulp_ansible.app.tasks.collections import declarative_content_from_git_repo
 
 log = logging.getLogger(__name__)
 
@@ -76,71 +69,8 @@ class GitFirstStage(Stage):
         async with ProgressReport(
             message="Cloning Git repository for Collection", code="sync.git.clone"
         ) as pb:
-            if self.remote.git_ref:
-                try:
-                    gitrepo = Repo.clone_from(
-                        self.remote.url, self.remote.name, depth=1, branch=self.remote.git_ref
-                    )
-                except GitCommandError:
-                    gitrepo = Repo.clone_from(self.remote.url, self.remote.name)
-                    gitrepo.git.checkout(self.remote.git_ref)
-            else:
-                gitrepo = Repo.clone_from(self.remote.url, self.remote.name, depth=1)
-            commit_sha = gitrepo.head.commit.hexsha
-            metadata, artifact_path = sync_collection(gitrepo.working_dir, ".")
-            if not self.remote.metadata_only:
-                artifact = Artifact.init_and_validate(artifact_path)
-                try:
-                    await sync_to_async(artifact.save)()
-                except IntegrityError:
-                    artifact = Artifact.objects.get(sha256=artifact.sha256)
-                metadata["artifact_url"] = reverse("artifacts-detail", args=[artifact.pk])
-                metadata["artifact"] = artifact
-            else:
-                metadata["artifact"] = None
-                metadata["artifact_url"] = None
-            metadata["remote_artifact_url"] = "{}/commit/{}".format(
-                self.remote.url.rstrip("/"), commit_sha
+            d_content = await declarative_content_from_git_repo(
+                self.remote, self.remote.url, self.remote.git_ref, self.metadata_only
             )
-            await self._add_collection_version(metadata)
+            await self.put(d_content)
             await pb.aincrement()
-
-    async def _add_collection_version(self, metadata):
-        """Add CollectionVersion to the sync pipeline."""
-        artifact = metadata["artifact"]
-        try:
-            collection_version = await sync_to_async(create_collection_from_importer)(
-                metadata, metadata_only=self.remote.metadata_only
-            )
-            await sync_to_async(ContentArtifact.objects.get_or_create)(
-                artifact=artifact,
-                content=collection_version,
-                relative_path=collection_version.relative_path,
-            )
-        except ValidationError as e:
-            if e.args[0]["non_field_errors"][0].code == "unique":
-                namespace = metadata["metadata"]["namespace"]
-                name = metadata["metadata"]["name"]
-                version = metadata["metadata"]["version"]
-            else:
-                raise e
-            collection_version = await sync_to_async(CollectionVersion.objects.get)(
-                namespace=namespace, name=name, version=version
-            )
-        if artifact is None:
-            artifact = Artifact()
-        d_artifact = DeclarativeArtifact(
-            artifact=artifact,
-            url=metadata["remote_artifact_url"],
-            relative_path=collection_version.relative_path,
-            remote=self.remote,
-            deferred_download=self.metadata_only,
-        )
-
-        # TODO: docs blob support??
-
-        d_content = DeclarativeContent(
-            content=collection_version,
-            d_artifacts=[d_artifact],
-        )
-        await self.put(d_content)

--- a/pulp_ansible/app/tasks/utils.py
+++ b/pulp_ansible/app/tasks/utils.py
@@ -4,7 +4,6 @@ import logging
 import json
 import re
 import yaml
-
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from rest_framework.serializers import ValidationError
 from yaml.error import YAMLError


### PR DESCRIPTION
The Collection Remote can now be used to sync Collections that were synced using Git Remote with just metadata.
The sync using Collection Remote always saves the artifact.

closes: #778
