### PR TITLE
Adds workaround for `requires_ansible`

### DIFF
--- a/CHANGES/806.bugfix
+++ b/CHANGES/806.bugfix
@@ -1,0 +1,2 @@
+Adds workaround to handle collections that do not have a ``requires_ansible`` in the
+``meta/runtime.yml`` data. This can happen in collections from ``galaxy.ansible.com``.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -1046,7 +1046,10 @@ class CollectionContentSaver(ContentSaver):
                     )
                     if runtime_metadata:
                         runtime_yaml = yaml.safe_load(runtime_metadata)
-                        collection_version.requires_ansible = runtime_yaml.get("requires_ansible")
+                        if runtime_yaml:
+                            collection_version.requires_ansible = runtime_yaml.get(
+                                "requires_ansible"
+                            )
                     manifest_data = json.load(
                         get_file_obj_from_tarball(tar, "MANIFEST.json", artifact.file.name)
                     )


### PR DESCRIPTION
Collections on galaxy.ansible.com may not have the expected
`requires_ansible` data.

closes #806