### PR TITLE
Update collection deletion task to clean up related content

### DIFF
--- a/CHANGES/889.bugfix
+++ b/CHANGES/889.bugfix
@@ -1,0 +1,2 @@
+Fix a bug where when a collection version is removed from a repository, it's associated signatures
+and deprecated content remains in the repository.

--- a/pulp_ansible/tests/functional/utils.py
+++ b/pulp_ansible/tests/functional/utils.py
@@ -46,6 +46,7 @@ from pulpcore.client.pulp_ansible import (
     RemotesRoleApi,
     AnsibleRepositorySyncURL,
     PulpAnsibleArtifactsCollectionsV3Api,
+    RepositoriesAnsibleVersionsApi,
 )
 
 from orionutils.generator import build_collection, randstr
@@ -221,6 +222,7 @@ class TestCaseUsingBindings(PulpTestCase):
         """Create class-wide variables."""
         cls.client = gen_ansible_client()
         cls.repo_api = RepositoriesAnsibleApi(cls.client)
+        cls.repo_version_api = RepositoriesAnsibleVersionsApi(cls.client)
         cls.remote_collection_api = RemotesCollectionApi(cls.client)
         cls.remote_git_api = RemotesGitApi(cls.client)
         cls.remote_role_api = RemotesRoleApi(cls.client)


### PR DESCRIPTION
Collection deletion task was not correctly deleting associated signatures and deprecation content.