### PR TITLE
Remove repository lock from V3 Collection Import endpoint

### DIFF
--- a/CHANGES/1105.feature
+++ b/CHANGES/1105.feature
@@ -1,0 +1,2 @@
+Removed repository lock for the import process of the V3 Collection Import endpoint.
+Task now generates a secondary task with the repository lock to add the content to the repository.

--- a/pulp_ansible/app/galaxy/mixins.py
+++ b/pulp_ansible/app/galaxy/mixins.py
@@ -1,3 +1,4 @@
+from pulpcore.plugin.models import TaskGroup
 from pulpcore.plugin.tasking import dispatch
 
 from pulp_ansible.app.tasks.collections import import_collection
@@ -19,3 +20,15 @@ class UploadGalaxyCollectionMixin:
             kwargs["repository_pk"] = repository.pk
 
         return dispatch(import_collection, exclusive_resources=locks, kwargs=kwargs)
+
+    def _dispatch_import_collection_task_lockless(self, temp_file_pk, repository, **kwargs):
+        """
+        Dispatch a Import Collection creation task without any locking on the repository.
+        """
+        kwargs["temp_file_pk"] = temp_file_pk
+        kwargs["lockless"] = True
+        task_group = TaskGroup.objects.create(description=f"Import collection to {repository.name}")
+        kwargs["repository_pk"] = repository.pk
+
+        async_result = dispatch(import_collection, task_group=task_group, kwargs=kwargs)
+        return task_group, async_result

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -510,7 +510,7 @@ class CollectionUploadViewSet(
         if serializer.validated_data["expected_version"]:
             kwargs["expected_version"] = serializer.validated_data["expected_version"]
 
-        async_result = self._dispatch_import_collection_task(
+        task_group, async_result = self._dispatch_import_collection_task_lockless(
             temp_file.pk, distro.repository, **kwargs
         )
         CollectionImport.objects.create(task_id=async_result.pk)


### PR DESCRIPTION
fixes: #1105

Right  now this is the bare minimum changes required to remove the repository lock from the initial import task. However, I think we should look into changing the `CollectionImport` model to accommodate for the new task group which would require a migration. @newswangerd 

TODO:

- [ ] Add/modify current tests
- [ ] Decide on how much info the `CollectionImport` model should report