### PR TITLE
Loosen the jsonschema requirements to match e.g. ansible-lint's requirement

### DIFF
--- a/CHANGES/1202.bugfix
+++ b/CHANGES/1202.bugfix
@@ -1,0 +1,1 @@
+Update the jsonschema requirements to not conflict with ansible-lint. Currently ansible-lint requires at least 4.9, so match that.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles>=0.8.0,<0.9
 async_lru>=1.0,<1.1
 galaxy_importer>=0.4.5,<0.5
 GitPython>=3.1.24,<3.2
-jsonschema>=4.4,<4.7
+jsonschema>=4.9,<4.10
 packaging>=21.3,<22
 pulpcore>=3.21.dev,<3.25
 PyYAML<6.0


### PR DESCRIPTION
Ansible lint requires jsonschema version at least 4.9, so loosen up the requirements a bit.

fixes #1202