### PR TITLE
Update the jsonschema requirements to not conflict with ansible-lint

### DIFF
--- a/CHANGES/1202.bugfix
+++ b/CHANGES/1202.bugfix
@@ -1,0 +1,1 @@
+Update the jsonschema requirements to not conflict with ansible-lint. Currently ansible-lint requires at least 4.9, so match that.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 async_lru>=1.0,<1.1
 galaxy_importer>=0.4.5,<0.5
 GitPython>=3.1.24,<3.2
-jsonschema>=4.4,<4.7
+jsonschema>=4.4,<4.10
 packaging>=21,<22
 pulpcore>=3.20,<3.25
 PyYAML<6.0


### PR DESCRIPTION
Currently ansible-lint requires at least 4.9, so match that.

fixes  #1202

EDIT: Kept the lower bound of the requirement.

(cherry picked from commit 76c19748f6aed6d77da1f13f7b74311762859b85)