### PR TITLE
Drop jsonschema from requirements

### DIFF
--- a/CHANGES/1242.misc
+++ b/CHANGES/1242.misc
@@ -1,0 +1,1 @@
+Drop jsonschema from requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 async_lru>=1.0,<1.1
 galaxy_importer>=0.4.5,<0.5
 GitPython>=3.1.24,<3.2
-jsonschema>=4.9,<4.10
 packaging>=21.3,<22
 pulpcore>=3.21.dev,<3.25
 PyYAML<6.0


### PR DESCRIPTION
Let pulp-ansible uses jsonschema from ansible-lint

closes #1242