### PR TITLE
Add pulp-smash as a unittest requirement.

### DIFF
--- a/unittest_requirements.txt
+++ b/unittest_requirements.txt
@@ -1,2 +1,3 @@
 mock
+pulp-smash @ git+https://github.com/pulp/pulp-smash.git
 pytest-django


### PR DESCRIPTION
Even though pulp_ansible doesn't use pulp-smash directly it's still needed when you want to run the unit tests in the oci_dev env. The unittests are loaded with pytest, which loads pulpcore as a pytest plugin, which then tries to load pulp-smash pytest plugin and fails.

[noissue]