### PR TITLE
Add missing params to `rebuild_metadata` in `AnsibleRepositoryViewSet`

### DIFF
--- a/CHANGES/1322.bugfix
+++ b/CHANGES/1322.bugfix
@@ -1,0 +1,1 @@
+Fixed a 500 server error in the ``repositories/ansible/ansible/{repository_pk}/versions/{number}/rebuild_metadata/`` endpoint.

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -378,8 +378,7 @@ class AnsibleRepositoryVersionViewSet(RepositoryVersionViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     @action(detail=True, methods=["post"], serializer_class=AnsibleRepositoryRebuildSerializer)
-    # def rebuild_metadata(self, request, *args, **kwargs):
-    def rebuild_metadata(self, request, pk):
+    def rebuild_metadata(self, request, *args, **kwargs):
         """
         Dispatches a collection version rebuild task.
         """

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -378,7 +378,8 @@ class AnsibleRepositoryVersionViewSet(RepositoryVersionViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     @action(detail=True, methods=["post"], serializer_class=AnsibleRepositoryRebuildSerializer)
-    def rebuild_metadata(self, request, *args, **kwargs):
+    # def rebuild_metadata(self, request, *args, **kwargs):
+    def rebuild_metadata(self, request, pk):
         """
         Dispatches a collection version rebuild task.
         """

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -378,7 +378,7 @@ class AnsibleRepositoryVersionViewSet(RepositoryVersionViewSet):
         responses={202: AsyncOperationResponseSerializer},
     )
     @action(detail=True, methods=["post"], serializer_class=AnsibleRepositoryRebuildSerializer)
-    def rebuild_metadata(self, request, pk):
+    def rebuild_metadata(self, request, *args, **kwargs):
         """
         Dispatches a collection version rebuild task.
         """


### PR DESCRIPTION
fixes: https://github.com/pulp/pulp_ansible/issues/1322

Endpoint `/api/automation-hub/pulp/api/v3/repositories/ansible/ansible/{repository_pk}/versions/0/rebuild_metadata/` fails with `Server error 500` 

`rebuild_metada` params are missing `number` and `repository_pk`

```
pulp_1   | pulp [None]: django.request:ERROR: Internal Server Error: /api/automation-hub/pulp/api/v3/repositories/ansible/ansible/78a1653e-e6c7-4d5a-96c4-2ddfaef720dd/versions/0/rebuild_metadata/
pulp_1   | Traceback (most recent call last):
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
pulp_1   |     response = get_response(request)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
pulp_1   |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
pulp_1   |     return view_func(*args, **kwargs)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/rest_framework/viewsets.py", line 125, in view
pulp_1   |     return self.dispatch(request, *args, **kwargs)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
pulp_1   |     response = self.handle_exception(exc)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
pulp_1   |     self.raise_uncaught_exception(exc)
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
pulp_1   |     raise exc
pulp_1   |   File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
pulp_1   |     response = handler(request, *args, **kwargs)
pulp_1   | TypeError: rebuild_metadata() got an unexpected keyword argument 'repository_pk'
```
Error only occurs for `rebuilding_metadata` in `AnsibleRepositoryVersionViewSet`, `AnsibleRepositoryViewSet` works fine 