### PR TITLE
Repo management improvements - url filtering and last sync time

### DIFF
--- a/CHANGES/1344.feature
+++ b/CHANGES/1344.feature
@@ -1,0 +1,2 @@
+Added last_sync_task field to CollectionRemote and AnsibleRepository
+Added filtering by url in CollectionRemote

--- a/CHANGES/1344.feature
+++ b/CHANGES/1344.feature
@@ -1,2 +1,2 @@
-Added last_sync_task field to CollectionRemote and AnsibleRepository
-Added filtering by url in CollectionRemote
+Added ``last_sync_task`` field to ``CollectionRemote`` and ``AnsibleRepository``.
+Added filtering by ``url`` in ``CollectionRemote``.

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -19,6 +19,7 @@ from pulpcore.plugin.serializers import (
     DistributionSerializer,
     RepositoryVersionRelatedField,
     validate_unknown_fields,
+    TaskSerializer,
 )
 from rest_framework.exceptions import ValidationError
 
@@ -126,6 +127,7 @@ class AnsibleRepositorySerializer(RepositorySerializer):
     last_synced_metadata_time = serializers.DateTimeField(
         help_text=_("Last synced metadata time."), allow_null=True, required=False
     )
+    last_sync_task = TaskSerializer(read_only=True)
     gpgkey = serializers.CharField(
         help_text="Gpg public key to verify collection signatures against",
         required=False,
@@ -136,6 +138,7 @@ class AnsibleRepositorySerializer(RepositorySerializer):
         fields = RepositorySerializer.Meta.fields + (
             "last_synced_metadata_time",
             "gpgkey",
+            "last_sync_task",
         )
         model = AnsibleRepository
 
@@ -211,6 +214,8 @@ class CollectionRemoteSerializer(RemoteSerializer):
         default=False,
     )
 
+    last_sync_task = TaskSerializer(read_only=True)
+
     def validate(self, data):
         """
         Validate collection remote data.
@@ -262,6 +267,7 @@ class CollectionRemoteSerializer(RemoteSerializer):
             "token",
             "sync_dependencies",
             "signed_only",
+            "last_sync_task",
         )
         model = CollectionRemote
 

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -19,6 +19,7 @@ from pulpcore.plugin.viewsets import (
     DistributionViewSet,
     BaseFilterSet,
     ContentFilter,
+    RemoteFilter,
     ContentViewSet,
     HyperlinkRelatedFilter,
     NamedModelViewSet,
@@ -171,6 +172,12 @@ class CollectionVersionFilter(ContentFilter):
     class Meta:
         model = CollectionVersion
         fields = ["namespace", "name", "version", "q", "is_highest", "tags"]
+
+
+class CollectionRemoteFilter(RemoteFilter):
+    class Meta:
+        model = CollectionRemote
+        fields = {"url": ["exact", "in", "icontains", "contains"], **RemoteFilter.Meta.fields}
 
 
 class CollectionVersionViewSet(UploadGalaxyCollectionMixin, SingleArtifactContentUploadViewSet):
@@ -407,6 +414,7 @@ class CollectionRemoteViewSet(RemoteViewSet):
     endpoint_name = "collection"
     queryset = CollectionRemote.objects.all()
     serializer_class = CollectionRemoteSerializer
+    filterset_class = CollectionRemoteFilter
 
     def async_reserved_resources(self, instance):
         if instance is None:


### PR DESCRIPTION
fixes: #1344 
AAH issue: [AAH-2076](https://issues.redhat.com/browse/AAH-2076)

For repo management, we need little improvements for our galaxy_ng and UI (ansible-hub-ui)
- filtering by `url` in `CollectionRemote`
- last sync status (`finished_at`, `status`, `error`) for `CollectionRemoteSerializer` and `AnsibleRepositorySerializer`

(AnsibleRepository has `last_synced_metadata_time` field, but it's always null, even after sync) 
