### PR TITLE
Add sync total to collection sync first stage

### DIFF
--- a/CHANGES/1219.feature
+++ b/CHANGES/1219.feature
@@ -1,0 +1,1 @@
+Added "total" count on "sync.parsing.metadata" progress report.


### PR DESCRIPTION
fixes: #1219

@newswangerd This is the best I can do for updating totals in the sync progress report. The other reports are apart of pulpcore and are designed without foreknowledge of the final total. 