### PR TITLE
Limit upper version bound of setuptools

### DIFF
--- a/CHANGES/1340.bugfix
+++ b/CHANGES/1340.bugfix
@@ -1,0 +1,2 @@
+Pinned the dependency upper bound on setuptools to <66.2.0. Newer versions introduce stricter
+PEP-440 parsing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ packaging>=21.3,<24
 pulpcore>=3.21.dev,<3.25
 PyYAML>=5.4.1,<7.0
 semantic_version>=2.9,<2.11
+setuptools>=39.2,<66.2.0


### PR DESCRIPTION
Setuptools updated their version of packaging, which in turn introduced stronger PEP-440 checking on versions, so we can no longer rely on that for semver requirement parsing.
Pinning to the old version is only meant to be a temporary solution.

fixes #1340