### PR TITLE
Limit upper version bound of setuptools (#1341)

### DIFF
--- a/CHANGES/1340.bugfix
+++ b/CHANGES/1340.bugfix
@@ -1,0 +1,2 @@
+Pinned the dependency upper bound on setuptools to <66.2.0. Newer versions introduce stricter
+PEP-440 parsing.

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -846,7 +846,6 @@ def redirect_view_generator(actions, url, viewset, distro_view=True, responses={
     # subclasses viewset to make .as_view work correctly on non viewset views
     # subclasses the redirected viewset to get pagination class and query params
     class GeneratedRedirectView(RedirectView, viewsets.ViewSet, viewset):
-
         permanent = False
 
         def urlpattern(*args, **kwargs):

--- a/pulp_ansible/tests/functional/api/collection/v3/test_content_guard.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_content_guard.py
@@ -35,7 +35,6 @@ class CollectionDownloadTestCase(TestCaseUsingBindings, SyncHelpersMixin):
         self.distribution = self._create_distribution_from_repo(self.first_repo)
 
     def _get_download_url(self, namespace, name):
-
         collection_api = PulpAnsibleDefaultApiV3PluginAnsibleContentCollectionsIndexApi(self.client)
         versions_api = PulpAnsibleDefaultApiV3PluginAnsibleContentCollectionsIndexVersionsApi(
             self.client

--- a/pulp_ansible/tests/functional/api/git/test_sync.py
+++ b/pulp_ansible/tests/functional/api/git/test_sync.py
@@ -54,7 +54,6 @@ class GitRemoteSyncInstallTestCase(TestCaseUsingBindings, SyncHelpersMixin):
         self.addCleanup(self.distributions_api.delete, distribution.pulp_href)
         collection_name = "pulp.squeezer"
         with tempfile.TemporaryDirectory() as temp_dir:
-
             # The install command needs --pre so a pre-release collection versions install
             cmd = "ansible-galaxy collection install --pre {} -c -s {} -p {}".format(
                 collection_name, distribution.client_url, temp_dir

--- a/pulp_ansible/tests/functional/conftest.py
+++ b/pulp_ansible/tests/functional/conftest.py
@@ -59,6 +59,18 @@ def ansible_repo(ansible_repo_api_client, gen_object_with_cleanup):
 
 
 @pytest.fixture
+def ansible_repo_factory(ansible_repo_api_client, gen_object_with_cleanup):
+    """A factory that creates an Ansible Repository and deletes it at test cleanup time."""
+
+    def _ansible_repo_factory(**kwargs):
+        body = gen_repo()
+        body.update(kwargs)
+        return gen_object_with_cleanup(ansible_repo_api_client, body)
+
+    return _ansible_repo_factory
+
+
+@pytest.fixture
 def gen_ansible_distribution(ansible_distro_api_client, gen_object_with_cleanup):
     """A factory to generate an Ansible Distribution and auto-deletes them at test cleanup time."""
 
@@ -78,3 +90,6 @@ def gen_ansible_collection_remote(ansible_remote_collection_api_client, gen_obje
         return gen_object_with_cleanup(ansible_remote_collection_api_client, kwargs)
 
     yield _gen_ansible_collection_remote
+
+
+ansible_collection_remote_factory = gen_ansible_collection_remote

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ packaging~=21.3
 pulpcore>=3.18,<3.20
 PyYAML<6.0
 semantic_version~=2.10
+setuptools>=39.2,<66.2.0


### PR DESCRIPTION
Setuptools updated their version of packaging, which in turn introduced stronger PEP-440 checking on versions, so we can no longer rely on that for semver requirement parsing.
Pinning to the old version is only meant to be a temporary solution.

fixes #1340

(cherry picked from commit 3d4ddb81e48b1f4209bd49b56a8d8924ceb12082)