### PR TITLE
Limit upper version bound of setuptools (#1341)

### DIFF
--- a/CHANGES/1340.bugfix
+++ b/CHANGES/1340.bugfix
@@ -1,0 +1,2 @@
+Pinned the dependency upper bound on setuptools to <66.2.0. Newer versions introduce stricter
+PEP-440 parsing.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ packaging~=21.3
 pulpcore>=3.15.1,<3.17
 PyYAML<6.0
 semantic_version~=2.10
+setuptools>=39.2,<66.2.0


### PR DESCRIPTION
Setuptools updated their version of packaging, which in turn introduced stronger PEP-440 checking on versions, so we can no longer rely on that for semver requirement parsing.
Pinning to the old version is only meant to be a temporary solution.

fixes #1340

(cherry picked from commit 3d4ddb81e48b1f4209bd49b56a8d8924ceb12082)