### PR TITLE
Bump the required pulpcore version to 3.23dev

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ galaxy_importer>=0.4.5,<0.5
 GitPython>=3.1.24,<3.2
 jsonschema>=4.9,<4.18
 Pillow>=7.0,<9.5
-pulpcore>=3.21.dev,<3.25
+pulpcore>=3.23.dev,<3.25
 PyYAML>=5.4.1,<7.0
 semantic_version>=2.9,<2.11


### PR DESCRIPTION
This is needed for some plugin api exports.

[noissue]