### PR TITLE
hotfix: Add default value for signatures and marks

### DIFF
--- a/CHANGES/1387.bugfix
+++ b/CHANGES/1387.bugfix
@@ -1,0 +1,1 @@
+Fixed broken sync form servers without signatures or marks.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -589,8 +589,8 @@ class CollectionSyncFirstStage(Stage):
         self.already_synced.add(cv_unique)
 
         info = metadata["metadata"]
-        signatures = metadata.get("signatures")
-        marks = metadata.get("marks")  # List[str]
+        signatures = metadata.get("signatures", [])
+        marks = metadata.get("marks", [])
 
         if self.signed_only and not signatures:
             return


### PR DESCRIPTION
When syncing from a remote that has no marks or no signatures (older version) this ensures the field on sync defaults to empty list avoiding iteration error.

fixes: #1387