### PR TITLE
Add API endpoint for copying and moving content between repos.

### DIFF
--- a/CHANGES/1394.feature
+++ b/CHANGES/1394.feature
@@ -1,0 +1,2 @@
+Create POST {repo_href}/copy_collection_version/ and POST {repo_href}/copy_collection_version/
+API endpoints which allow for copying and moving collections between repos.

--- a/CHANGES/1394.feature
+++ b/CHANGES/1394.feature
@@ -1,2 +1,3 @@
-Create POST {repo_href}/copy_collection_version/ and POST {repo_href}/copy_collection_version/
-API endpoints which allow for copying and moving collections between repos.
+Created POST ``{repo_href}/copy_collection_version/`` and POST
+``{repo_href}/copy_collection_version/`` API endpoints which
+allow for copying and moving collections between repos.

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -866,7 +866,7 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
         )
 
 
-class CollectionVersionMarkSerializer(ModelSerializer):
+class CollectionVersionMarkSerializer(NoArtifactContentSerializer):
     """
     A serializer for mark models.
     """
@@ -883,7 +883,7 @@ class CollectionVersionMarkSerializer(ModelSerializer):
 
     class Meta:
         model = CollectionVersionMark
-        fields = ["marked_collection", "value"]
+        fields = ["pulp_created", "pulp_href", "marked_collection", "value"]
 
 
 class AnsibleRepositoryMarkSerializer(serializers.Serializer):
@@ -961,6 +961,38 @@ class CollectionImportDetailSerializer(CollectionImportListSerializer):
 
     class Meta(CollectionImportListSerializer.Meta):
         fields = CollectionImportListSerializer.Meta.fields + ("error", "messages")
+
+
+class CollectionVersionCopyMoveSerializer(serializers.Serializer):
+    """
+    Copy or move collections from a source repository into one or mor destinations.
+    """
+
+    collection_versions = DetailRelatedField(
+        required=True,
+        view_name_pattern=r"content(-.*/.*)-detail",
+        queryset=CollectionVersion.objects.all(),
+        help_text=_("A list of collection versions to move or copy."),
+        many=True,
+    )
+
+    destination_repositories = DetailRelatedField(
+        required=True,
+        view_name="repositories-ansible/ansible-detail",
+        queryset=AnsibleRepository.objects.all(),
+        help_text=_("List of repository HREFs to put content in."),
+        many=True,
+    )
+
+    signing_service = RelatedField(
+        required=False,
+        view_name="signing-services-detail",
+        queryset=SigningService.objects.all(),
+        help_text=_(
+            "HREF for a signing service. This will be used to sign the collection "
+            "before moving putting it in any new repositories."
+        ),
+    )
 
 
 class CopySerializer(serializers.Serializer):

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -965,12 +965,14 @@ class CollectionImportDetailSerializer(CollectionImportListSerializer):
 
 class CollectionVersionCopyMoveSerializer(serializers.Serializer):
     """
-    Copy or move collections from a source repository into one or mor destinations.
+    Copy or move collections from a source repository into one or more destinations.
+
+    This will carry associated content like Signatures and Marks along.
     """
 
     collection_versions = DetailRelatedField(
         required=True,
-        view_name_pattern=r"content(-.*/.*)-detail",
+        view_name=r"content-ansible/collection_versions-detail",
         queryset=CollectionVersion.objects.all(),
         help_text=_("A list of collection versions to move or copy."),
         many=True,

--- a/pulp_ansible/app/tasks/copy.py
+++ b/pulp_ansible/app/tasks/copy.py
@@ -140,14 +140,15 @@ def move_collection(cv_pk_list, src_repo_pk, dest_repo_list):
 
 
 def copy_or_move_and_sign(copy_or_move, signing_service_pk=None, **move_task_kwargs):
-    if signing_service_pk:
-        sign(
-            signing_service_href=signing_service_pk,
-            repository_href=move_task_kwargs["src_repo_pk"],
-            content_hrefs=move_task_kwargs["cv_pk_list"],
-        )
-
     if copy_or_move == "copy":
         copy_collection(**move_task_kwargs)
     else:
         move_collection(**move_task_kwargs)
+
+    if signing_service_pk:
+        for pk in move_task_kwargs["dest_repo_list"]:
+            sign(
+                signing_service_href=signing_service_pk,
+                repository_href=pk,
+                content_hrefs=move_task_kwargs["cv_pk_list"],
+            )

--- a/pulp_ansible/app/tasks/copy.py
+++ b/pulp_ansible/app/tasks/copy.py
@@ -2,7 +2,18 @@ from django.db import transaction
 from django.db.models import Q
 from pulpcore.plugin.models import RepositoryVersion
 
-from pulp_ansible.app.models import AnsibleRepository
+from pulp_ansible.app.models import (
+    CollectionVersion,
+    CollectionVersionSignature,
+    AnsibleCollectionDeprecated,
+    CollectionVersionMark,
+    AnsibleNamespaceMetadata,
+    AnsibleRepository,
+)
+
+from pulpcore.plugin.tasking import add_and_remove
+
+from .signature import sign
 
 
 @transaction.atomic
@@ -62,3 +73,80 @@ def copy_content(config):
         base_version = dest_repo_version if dest_version_provided else None
         with dest_repo.new_version(base_version=base_version) as new_version:
             new_version.add_content(content_to_copy)
+
+
+def copy_collection(cv_pk_list, src_repo_pk, dest_repo_list):
+    """
+    Copy a collection and all of it's contents into a list of destination repositories
+    """
+    src_repo = AnsibleRepository.objects.get(pk=src_repo_pk)
+    collection_versions = CollectionVersion.objects.filter(pk__in=cv_pk_list)
+
+    content_types = src_repo.content.values_list("pulp_type", flat=True).distinct()
+    source_pks = src_repo.content.values_list("pk", flat=True)
+
+    content = cv_pk_list
+
+    # collection signatures
+    if "ansible.collection_signature" in content_types:
+        signatures_pks = CollectionVersionSignature.objects.filter(
+            signed_collection__in=cv_pk_list, pk__in=source_pks
+        ).values_list("pk", flat=True)
+        if signatures_pks:
+            content.extend(signatures_pks)
+
+    # collection version mark
+    if "ansible.collection_mark" in content_types:
+        marks_pks = CollectionVersionMark.objects.filter(
+            marked_collection__in=cv_pk_list, pk__in=source_pks
+        ).values_list("pk", flat=True)
+        if marks_pks:
+            content.extend(marks_pks)
+
+    # namespace metadata
+    namespaces = {x.namespace for x in collection_versions}
+    namespaces_pks = AnsibleNamespaceMetadata.objects.filter(
+        pk__in=source_pks,
+        name__in=list(namespaces),
+    ).values_list("pk", flat=True)
+    if namespaces_pks:
+        content.extend(namespaces_pks)
+
+    # collection deprecation
+    for cv in collection_versions:
+        if "ansible.collection_deprecation" in content_types:
+            deprecations_pks = AnsibleCollectionDeprecated.objects.filter(
+                pk__in=source_pks,
+                namespace=cv.namespace,
+                name=cv.name,
+            ).values_list("pk", flat=True)
+            if deprecations_pks:
+                content.extend(deprecations_pks)
+
+    for pk in dest_repo_list:
+        add_and_remove(repository_pk=pk, add_content_units=content, remove_content_units=[])
+
+
+def move_collection(cv_pk_list, src_repo_pk, dest_repo_list):
+    """
+    Copy a collection and all of it's contents into a list of destination repositories
+    """
+    copy_collection(cv_pk_list, src_repo_pk, dest_repo_list)
+
+    # don't need to clean anything other than the collection version because everything
+    # else will get handled by AnsibleRepository.finalize_repo_version()
+    add_and_remove(repository_pk=src_repo_pk, add_content_units=[], remove_content_units=cv_pk_list)
+
+
+def copy_or_move_and_sign(copy_or_move, signing_service_pk=None, **move_task_kwargs):
+    if signing_service_pk:
+        sign(
+            signing_service_href=signing_service_pk,
+            repository_href=move_task_kwargs["src_repo_pk"],
+            content_hrefs=move_task_kwargs["cv_pk_list"],
+        )
+
+    if copy_or_move == "copy":
+        copy_collection(**move_task_kwargs)
+    else:
+        move_collection(**move_task_kwargs)

--- a/pulp_ansible/app/tasks/copy.py
+++ b/pulp_ansible/app/tasks/copy.py
@@ -77,7 +77,8 @@ def copy_content(config):
 
 def copy_collection(cv_pk_list, src_repo_pk, dest_repo_list):
     """
-    Copy a collection and all of it's contents into a list of destination repositories
+    Copy a list of collection versions and all of it's related contents into a
+    list of destination repositories.
     """
     src_repo = AnsibleRepository.objects.get(pk=src_repo_pk)
     collection_versions = CollectionVersion.objects.filter(pk__in=cv_pk_list)
@@ -133,7 +134,7 @@ def move_collection(cv_pk_list, src_repo_pk, dest_repo_list):
     """
     copy_collection(cv_pk_list, src_repo_pk, dest_repo_list)
 
-    # don't need to clean anything other than the collection version because everything
+    # No need to remove anything other than the collection version because everything
     # else will get handled by AnsibleRepository.finalize_repo_version()
     add_and_remove(repository_pk=src_repo_pk, add_content_units=[], remove_content_units=cv_pk_list)
 

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -450,11 +450,6 @@ class AnsibleRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
         if signing_service:
             signing_service = signing_service.pk
 
-            # Reserve the source repository if a signing service is selected, so that
-            # signatures can be added.
-            reserved.append(repository)
-            shared = None
-
         result = dispatch(
             copy_or_move_and_sign,
             exclusive_resources=reserved,

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -68,10 +68,11 @@ from .serializers import (
     CopySerializer,
     RoleSerializer,
     TagSerializer,
+    CollectionVersionCopyMoveSerializer,
 )
 from .tasks.collections import sync as collection_sync
 from .tasks.collections import rebuild_repository_collection_versions_metadata
-from .tasks.copy import copy_content
+from .tasks.copy import copy_content, copy_or_move_and_sign
 from .tasks.roles import synchronize as role_sync
 from .tasks.git import synchronize as git_sync
 from .tasks.mark import mark, unmark
@@ -435,6 +436,57 @@ class AnsibleRepositoryViewSet(RepositoryViewSet, ModifyRepositoryActionMixin):
             },
         )
         return OperationPostponedResponse(result, request)
+
+    def _handle_copy_or_move(self, request, copy_or_move):
+        repository = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        dest_repos_pks = [x.pk for x in data["destination_repositories"]]
+
+        signing_service = data.get("signing_service", None)
+        if signing_service:
+            signing_service = signing_service.pk
+
+        reserved = data["destination_repositories"] + [repository]
+
+        result = dispatch(
+            copy_or_move_and_sign,
+            exclusive_resources=reserved,
+            kwargs={
+                "src_repo_pk": repository.pk,
+                "cv_pk_list": [x.pk for x in data["collection_versions"]],
+                "dest_repo_list": dest_repos_pks,
+                "copy_or_move": copy_or_move,
+                "signing_service_pk": signing_service,
+            },
+        )
+        return OperationPostponedResponse(result, request)
+
+    @extend_schema(
+        description="Trigger an asynchronous task to copy collection versions.",
+        responses={202: AsyncOperationResponseSerializer},
+    )
+    @action(detail=True, methods=["post"], serializer_class=CollectionVersionCopyMoveSerializer)
+    def copy_collection_version(self, request, pk):
+        """
+        Copy a collection and all of its associated content from this repository.
+        """
+
+        return self._handle_copy_or_move(request, "copy")
+
+    @extend_schema(
+        description="Trigger an asynchronous task to move collection versions.",
+        responses={202: AsyncOperationResponseSerializer},
+    )
+    @action(detail=True, methods=["post"], serializer_class=CollectionVersionCopyMoveSerializer)
+    def move_collection_version(self, request, pk):
+        """
+        Move a collection and all of its associated content from this repository.
+        """
+
+        return self._handle_copy_or_move(request, "move")
 
     def _handle_mark_task(self, request, task_function):
         """

--- a/pulp_ansible/tests/functional/api/collection/test_copy_and_move.py
+++ b/pulp_ansible/tests/functional/api/collection/test_copy_and_move.py
@@ -1,0 +1,305 @@
+import pytest
+from pulp_smash.pulp3.bindings import monitor_task
+from pulp_smash.pulp3.utils import gen_distribution
+from pulp_ansible.tests.functional.utils import iterate_all
+
+
+@pytest.fixture
+def repo_with_kitted_out_collection(
+    build_and_upload_collection,
+    ascii_armored_detached_signing_service,
+    ansible_repo,
+    ansible_repo_api_client,
+    ansible_distro_api_client,
+    galaxy_v3_plugin_namespaces_api_client,
+    galaxy_v3_content_collection_index_api,
+    content_api_client,
+    ansible_collection_signatures_client,
+    ansible_collection_mark_client,
+):
+    """
+    Create a repo that has a collection with all the possible associated content.
+
+    Repo contains 3 collections. 2 are returned to be copied, one of which has all
+    the content associated with it and the other of which as a mark and signature.
+
+    Returns the repo, two collections to copy and the list of expected content
+    after the copy operation happens.
+    """
+    collection, collection_url = build_and_upload_collection()
+    _, collection_url2 = build_and_upload_collection()
+    _, non_copied_collection = build_and_upload_collection()
+
+    # add collection to repo
+    body = {"add_content_units": [collection_url, collection_url2, non_copied_collection]}
+    monitor_task(ansible_repo_api_client.modify(ansible_repo.pulp_href, body).task)
+
+    # sign the collection
+    body = {
+        "content_units": [collection_url, collection_url2, non_copied_collection],
+        "signing_service": ascii_armored_detached_signing_service.pulp_href,
+    }
+    monitor_task(ansible_repo_api_client.sign(ansible_repo.pulp_href, body).task)
+
+    # Mark the collection
+    body = {
+        "content_units": [collection_url, collection_url2, non_copied_collection],
+        "value": "testable",
+    }
+    monitor_task(ansible_repo_api_client.mark(ansible_repo.pulp_href, body).task)
+
+    # Not gonna bother adding these to the first collection
+    # Create a distro for the repo
+    body = gen_distribution(repository=ansible_repo.pulp_href)
+    distro_href = monitor_task(ansible_distro_api_client.create(body).task).created_resources[0]
+    distro = ansible_distro_api_client.read(distro_href)
+
+    # Add a namespace for the collection
+    kwargs = {"path": distro.base_path, "distro_base_path": distro.base_path}
+    task = galaxy_v3_plugin_namespaces_api_client.create(
+        name=collection.namespace, description="hello", company="Testing Co.", **kwargs
+    )
+    monitor_task(task.task)
+
+    # Deprecate the collection
+    task = galaxy_v3_content_collection_index_api.update(
+        name=collection.name,
+        namespace=collection.namespace,
+        distro_base_path=distro.base_path,
+        body={"deprecated": True},
+    )
+    monitor_task(task.task)
+
+    repo = ansible_repo_api_client.read(ansible_repo.pulp_href)
+
+    expected_content = {
+        "collection_versions",
+        "namespaces",
+        "collection_signatures",
+        "collection_marks",
+        "collection_deprecations",
+    }
+
+    created_content = set()
+    all_content = set()
+    excluded_content = {non_copied_collection}
+
+    # get the signatures and marks from the excluded collection:
+    excluded_content = excluded_content.union(
+        {
+            x.pulp_href
+            for x in iterate_all(
+                ansible_collection_signatures_client.list, signed_collection=non_copied_collection
+            )
+        }
+    )
+
+    excluded_content = excluded_content.union(
+        {
+            x.pulp_href
+            for x in iterate_all(
+                ansible_collection_mark_client.list, marked_collection=non_copied_collection
+            )
+        }
+    )
+
+    assert len(excluded_content) >= 3
+
+    for content in iterate_all(
+        content_api_client.list, repository_version=repo.latest_version_href
+    ):
+        created_content.add(content.pulp_href.strip("/").split("/")[-2])
+        all_content.add(content.pulp_href)
+
+    assert expected_content == created_content
+
+    all_content = all_content.difference(excluded_content)
+
+    return repo, [collection_url, collection_url2], all_content, excluded_content
+
+
+@pytest.fixture
+def repo_with_one_out_collection(
+    build_and_upload_collection,
+    ansible_repo,
+    ansible_repo_api_client,
+):
+    """Create a distro serving two collections, one signed, one unsigned."""
+    collection, collection_url = build_and_upload_collection()
+
+    # add collection to repo
+    body = {"add_content_units": [collection_url]}
+    monitor_task(ansible_repo_api_client.modify(ansible_repo.pulp_href, body).task)
+
+    repo = ansible_repo_api_client.read(ansible_repo.pulp_href)
+
+    return repo, collection_url
+
+
+def test_copy_with_all_content(
+    repo_with_kitted_out_collection,
+    ansible_repo_factory,
+    ansible_repo_api_client,
+    content_api_client,
+):
+    """
+    Test copying a collection with all it's associated content
+    """
+    src_repo, collections, all_content, excluded = repo_with_kitted_out_collection
+
+    dest1 = ansible_repo_factory()
+    dest2 = ansible_repo_factory()
+    dest3 = ansible_repo_factory()
+
+    dest = (dest1, dest2, dest3)
+
+    task = ansible_repo_api_client.copy_collection_version(
+        src_repo.pulp_href,
+        {
+            "collection_versions": collections,
+            "destination_repositories": [x.pulp_href for x in dest],
+        },
+    )
+
+    monitor_task(task.task)
+
+    for repo in dest:
+        href = ansible_repo_api_client.read(repo.pulp_href).latest_version_href
+        dest_content = {
+            x.pulp_href for x in iterate_all(content_api_client.list, repository_version=href)
+        }
+
+        assert dest_content == all_content
+
+    href = ansible_repo_api_client.read(src_repo.pulp_href).latest_version_href
+    remaining = {c.pulp_href for c in iterate_all(content_api_client.list, repository_version=href)}
+
+    assert remaining == excluded.union(all_content)
+
+
+def test_move_with_all_content(
+    repo_with_kitted_out_collection,
+    ansible_repo_factory,
+    ansible_repo_api_client,
+    content_api_client,
+):
+    """
+    Test moving a collection with all it's associated content
+    """
+    src_repo, collections, all_content, excluded = repo_with_kitted_out_collection
+
+    dest1 = ansible_repo_factory()
+    dest2 = ansible_repo_factory()
+    dest3 = ansible_repo_factory()
+
+    dest = (dest1, dest2, dest3)
+
+    task = ansible_repo_api_client.move_collection_version(
+        src_repo.pulp_href,
+        {
+            "collection_versions": collections,
+            "destination_repositories": [x.pulp_href for x in dest],
+        },
+    )
+
+    monitor_task(task.task)
+
+    for repo in dest:
+        href = ansible_repo_api_client.read(repo.pulp_href).latest_version_href
+        dest_content = {
+            x.pulp_href for x in iterate_all(content_api_client.list, repository_version=href)
+        }
+
+        assert dest_content == all_content
+
+    href = ansible_repo_api_client.read(src_repo.pulp_href).latest_version_href
+    remaining = {c.pulp_href for c in iterate_all(content_api_client.list, repository_version=href)}
+
+    assert remaining == excluded
+
+
+def test_copy_and_sign(
+    ascii_armored_detached_signing_service,
+    ansible_repo_factory,
+    ansible_repo_api_client,
+    content_api_client,
+    repo_with_one_out_collection,
+    ansible_collection_signatures_client,
+    ansible_collection_version_api_client,
+):
+    """Verify that you can copy and sign a collection."""
+    src_repo, collection_url = repo_with_one_out_collection
+
+    dest1 = ansible_repo_factory()
+    dest2 = ansible_repo_factory()
+    dest3 = ansible_repo_factory()
+
+    dest = (dest1, dest2, dest3)
+
+    task = ansible_repo_api_client.copy_collection_version(
+        src_repo.pulp_href,
+        {
+            "collection_versions": [collection_url],
+            "destination_repositories": [x.pulp_href for x in dest],
+            "signing_service": ascii_armored_detached_signing_service.pulp_href,
+        },
+    )
+
+    monitor_task(task.task)
+
+    for repo in dest:
+        href = ansible_repo_api_client.read(repo.pulp_href).latest_version_href
+        assert content_api_client.list(repository_version=href).count == 2
+
+        collections = ansible_collection_version_api_client.list(repository_version=href)
+        assert collections.count == 1
+
+        signatures = ansible_collection_signatures_client.list(repository_version=href)
+        assert signatures.count == 1
+
+        assert signatures.results[0].signed_collection == collections.results[0].pulp_href
+
+
+def test_move_and_sign(
+    ascii_armored_detached_signing_service,
+    ansible_repo_factory,
+    ansible_repo_api_client,
+    content_api_client,
+    repo_with_one_out_collection,
+    ansible_collection_signatures_client,
+    ansible_collection_version_api_client,
+):
+    """Verify that you can move and sign a collection."""
+    src_repo, collection_url = repo_with_one_out_collection
+
+    dest1 = ansible_repo_factory()
+    dest2 = ansible_repo_factory()
+    dest3 = ansible_repo_factory()
+
+    dest = (dest1, dest2, dest3)
+
+    task = ansible_repo_api_client.move_collection_version(
+        src_repo.pulp_href,
+        {
+            "collection_versions": [collection_url],
+            "destination_repositories": [x.pulp_href for x in dest],
+            "signing_service": ascii_armored_detached_signing_service.pulp_href,
+        },
+    )
+
+    monitor_task(task.task)
+
+    for repo in dest:
+        href = ansible_repo_api_client.read(repo.pulp_href).latest_version_href
+        assert content_api_client.list(repository_version=href).count == 2
+
+        collections = ansible_collection_version_api_client.list(repository_version=href)
+        assert collections.count == 1
+
+        signatures = ansible_collection_signatures_client.list(repository_version=href)
+        assert signatures.count == 1
+
+        assert signatures.results[0].signed_collection == collections.results[0].pulp_href
+
+    href = ansible_repo_api_client.read(src_repo.pulp_href).latest_version_href
+    assert content_api_client.list(repository_version=href).count == 0


### PR DESCRIPTION
Allows for: `POST {repo_href}/copy_collection_version/` and `POST {repo_href}/copy_collection_version/` which allows for copying and moving collections between repos.

Payload:

```
{
  "collection_versions": ["href1", "href2"],       Collection version to move/copy,
  "destination_repositories": ["href1", "href2"],  List of repositories to copy/move the collection into
  "signing_service": "href"                        Optional. Sign the collections with the given signing service before copy/moving  
}
```