### PR TITLE
Semantic sorting on a CV list with many versions is extremely slow.

### DIFF
--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -866,9 +866,11 @@ class CollectionVersionViewSet(
         Returns paginated CollectionVersions list.
         """
         queryset = self.filter_queryset(self.get_queryset())
-        queryset = sorted(
-            queryset, key=lambda obj: semantic_version.Version(obj.version), reverse=True
-        )
+
+        # This is -very- slow when the collection has many versions.
+        # queryset = sorted(
+        #    queryset, key=lambda obj: semantic_version.Version(obj.version), reverse=True
+        # )
 
         context = self.get_serializer_context()
         page = self.paginate_queryset(queryset)


### PR DESCRIPTION
If a collection has many versions (200+), the versions list page is very slow to respond. The biggest time consumption comes from sorting the queryset by semantic version.  The queryset is already sorted by -pulp_created, which is probably sufficient considering the is_highest calculation elsewhere and how semantic version doesn't sort prereleases correctly below stable releases.

Before this patch:
```
$ time curl -s -L -u admin:admin 'http://localhost:5001/api/v3/plugin/ansible/content/published/collections/index/alvistack/gnome/versions/?limit=10' > /dev/null

real    0m6.025s
user    0m0.001s
sys     0m0.006s
```

After this patch:
```
$ time curl -s -L -u admin:admin 'http://localhost:5001/api/v3/plugin/ansible/content/published/collections/index/alvistack/gnome/versions/?limit=10' > /dev/null

real    0m0.425s
user    0m0.005s
sys     0m0.002s
```