### PR TITLE
Performance fix for collection version list.

### DIFF
--- a/CHANGES/1433.bugfix
+++ b/CHANGES/1433.bugfix
@@ -1,0 +1,1 @@
+Reduce fetched fields in cv list endpoint to prevent oomkill.

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,3 +1,4 @@
+ansible-core!=2.13.9,!=2.14.5
 pulp-smash @ git+https://github.com/pulp/pulp-smash.git
 orionutils
 pytest

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -865,7 +865,12 @@ class CollectionVersionViewSet(
         """
         Returns paginated CollectionVersions list.
         """
-        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self.get_queryset()
+
+        # prevent OOMKILL ...
+        queryset = queryset.only("pk", "content_ptr_id")
+
+        queryset = self.filter_queryset(queryset)
 
         # This is -very- slow when the collection has many versions.
         # queryset = sorted(


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2229

On a system with community.general's versions all synced, continuous queries against the list endpoint will consume all available memory until the worker is OOMKilled.

Thanks to @rochacbruno for the reproducer:
```
$ cat REPRO.sh 
#!/bin/bash

watch -n 1 \
curl -u admin:admin http://localhost:5001/api/automation-hub/v3/plugin/ansible/content/community/collections/index/community/general/versions/\?limit\=200\&offset\=0
```