### PR TITLE
Serializer.validate must return validated data

### DIFF
--- a/CHANGES/1441.bugfix
+++ b/CHANGES/1441.bugfix
@@ -1,0 +1,1 @@
+Fix traceback when publishing a collection to the v2 API endpoint

--- a/pulp_ansible/app/galaxy/serializers.py
+++ b/pulp_ansible/app/galaxy/serializers.py
@@ -191,7 +191,9 @@ class GalaxyCollectionUploadSerializer(serializers.Serializer):
 
     def validate(self, data):
         """Ensure duplicate artifact isn't uploaded."""
+        data = super().validate(data)
         sha256 = data["file"].hashers["sha256"].hexdigest()
         artifact = Artifact.objects.filter(sha256=sha256).first()
         if artifact:
             raise serializers.ValidationError(_("Artifact already exists"))
+        return data


### PR DESCRIPTION
It looks like way back in https://github.com/pulp/pulp_ansible/commit/357cdca6d4660e39d0006e794087b3d54241b5a2, at a minimum the v2, collection upload API was broken due to the addition of a `validate` method that did not return the validated data:

```pytb
pulp [3e989c26c1444f1abb437f8f61ac3ffe]: django.request:ERROR: Internal Server Error: /pulp_ansible/galaxy/primary/api/v2/collections/
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/pulp_ansible/app/galaxy/views.py", line 184, in post
    serializer.is_valid(raise_exception=True)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 227, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/serializers.py", line 430, in run_validation
    assert value is not None, '.validate() should return the validated data'
AssertionError: .validate() should return the validated data
```

A few things to note about tests:

1. The `pulp-ansible-client` package does not provide an API for uploading collections to the v2 collections API, only v3
2. Due to the above, afaict the tests are only testing the v3 collections API
3. I don't know how to write tests that test the v2 collections API as a result

[noissue]