### PR TITLE
Namespace compatibility changes

### DIFF
--- a/pulp_ansible/app/custom_fields.py
+++ b/pulp_ansible/app/custom_fields.py
@@ -16,7 +16,7 @@ from pulpcore.plugin.util import (
     get_groups_with_perms_attached_roles,
     get_perms_for_model
 )
-from django.contrib.auth.models import Group
+from pulpcore.plugin.models import Group
 
 
 class GroupModelPermissionsMixin:

--- a/pulp_ansible/app/custom_fields.py
+++ b/pulp_ansible/app/custom_fields.py
@@ -1,0 +1,208 @@
+from collections import OrderedDict
+
+from django.utils.translation import gettext_lazy as _
+from django.db import transaction
+from django.core.exceptions import BadRequest
+from django_lifecycle import hook
+
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+from pulpcore.plugin.models.role import Role
+
+from pulpcore.plugin.util import (
+    assign_role,
+    remove_role,
+    get_groups_with_perms_attached_roles,
+    get_perms_for_model
+)
+from django.contrib.auth.models import Group
+
+
+class GroupModelPermissionsMixin:
+    _groups = None
+
+    @property
+    def groups(self):
+        return get_groups_with_perms_attached_roles(
+            self, include_model_permissions=False, for_concrete_model=True)
+
+    @groups.setter
+    def groups(self, groups):
+        self._set_groups(groups)
+
+    @transaction.atomic
+    def _set_groups(self, groups):
+        # Can't add permissions to objects that haven't been
+        # saved. When creating new objects, save group data to _groups where it
+        # can be picked up by the post save hook.
+        if self._state.adding:
+            self._groups = groups
+        else:
+            obj = self
+
+            # If the model is a proxy model, get the original model since pulp
+            # doesn't allow us to assign permissions to proxied models.
+            if self._meta.proxy:
+                obj = self._meta.concrete_model.objects.get(pk=self.pk)
+
+            current_groups = get_groups_with_perms_attached_roles(
+                obj, include_model_permissions=False)
+            for group in current_groups:
+                for perm in current_groups[group]:
+                    remove_role(perm, group, obj)
+
+            for group in groups:
+                for role in groups[group]:
+                    try:
+                        assign_role(role, group, obj)
+                    except BadRequest:
+                        raise ValidationError(
+                            detail={'groups': _('Role {role} does not exist or does not '
+                                                'have any permissions related to this object.'
+                                                ).format(role=role)}
+                        )
+
+    @hook('after_save')
+    def set_object_groups(self):
+        if self._groups:
+            self._set_groups(self._groups)
+
+
+class RelatedFieldsBaseSerializer(serializers.Serializer):
+    """
+    Serializer only returns fields specified in 'include_related' query param.
+
+    This allows for fields that require more database queries to be optionally
+    included in API responses, which lowers the load on the backend. This is
+    intended as a way to include extra data in list views.
+
+    Usage:
+
+    This functions the same as DRF's base `serializers.Serializer` class with the
+    exception that it will only return fields specified in the `?include_related=`
+    query parameter.
+
+    Example:
+
+    MySerializer(RelatedFieldsBaseSerializer):
+        foo = CharField()
+        bar = CharField()
+
+    MySerializer will return:
+
+    {"foo": None} when called with `?include_related=foo` and {"foo": None, "bar" None}
+    when called with `?include_related=foo&include_related=bar`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # This should only be included as a sub serializer and shouldn't be used for
+        # updating objects, so set read_only to true
+        kwargs['read_only'] = True
+        return super().__init__(*args, **kwargs)
+
+    def to_representation(self, instance):
+        result = OrderedDict()
+        fields = self._readable_fields
+        request = self.context.get('request', None)
+        if request:
+
+            # TODO: Figure out how to make `include_related` show up in the open API spec
+            include_fields = request.GET.getlist('include_related')
+
+            if len(include_fields) > 0:
+                for field in fields:
+                    if field.field_name in include_fields:
+                        result[field.field_name] = field.to_representation(instance)
+        else:
+            # When there is no request present, it usually means that the serializer is
+            # being inspected by DRF spectacular to generate the open API spec. In that
+            # case, this should act like a normal serializer.
+            return super().to_representation(instance)
+
+        return result
+
+
+class MyPermissionsField(serializers.Serializer):
+    def to_representation(self, original_obj):
+        request = self.context.get('request', None)
+        if request is None:
+            return []
+        user = request.user
+
+        if original_obj._meta.proxy:
+            obj = original_obj._meta.concrete_model.objects.get(pk=original_obj.pk)
+        else:
+            obj = original_obj
+
+        my_perms = []
+        for perm in get_perms_for_model(type(obj)).all():
+            codename = "{}.{}".format(perm.content_type.app_label, perm.codename)
+            if user.has_perm(codename) or user.has_perm(codename, obj):
+                my_perms.append(codename)
+
+        return my_perms
+
+
+class GroupPermissionField(serializers.Field):
+    def _validate_group(self, group_data):
+        if 'object_roles' not in group_data:
+            raise ValidationError(detail={
+                'groups': _('object_roles field is required')})
+
+        if 'id' not in group_data and 'name' not in group_data:
+            raise ValidationError(detail={
+                'groups': _('id or name field is required')})
+
+        roles = group_data['object_roles']
+
+        if not isinstance(roles, list):
+            raise ValidationError(detail={
+                'groups': _('object_roles must be a list of strings')})
+
+        # validate that the permissions exist
+        for role in roles:
+            # TODO(newswangerd): Figure out how to make this one SQL query instead of
+            # performing N queries for each permission
+            if not Role.objects.filter(name=role).exists():
+                raise ValidationError(detail={
+                    'groups': _('Role {} does not exist').format(role)})
+
+    def to_representation(self, value):
+        rep = []
+        for group in value:
+            rep.append({
+                'id': group.id,
+                'name': group.name,
+                'object_roles': value[group]
+            })
+        return rep
+
+    def to_internal_value(self, data):
+        if not isinstance(data, list):
+            raise ValidationError(detail={
+                'groups': _('Groups must be a list of group objects')
+            })
+
+        internal = {}
+        for group_data in data:
+            self._validate_group(group_data)
+            group_filter = {}
+            for field in group_data:
+                if field in ('id', 'name'):
+                    group_filter[field] = group_data[field]
+            try:
+                group = Group.objects.get(**group_filter)
+                if 'object_permissions' in group_data:
+                    internal[group] = group_data['object_permissions']
+                if 'object_roles' in group_data:
+                    internal[group] = group_data['object_roles']
+            except Group.DoesNotExist:
+                raise ValidationError(detail={
+                    'groups': _("Group name=%s, id=%s does not exist") % (
+                        group_data.get('name'), group_data.get('id'))
+                })
+            except ValueError:
+                raise ValidationError(detail={'group': _('Invalid group name or ID')})
+
+        return internal

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse
 from rest_framework import serializers, relations
 
 from pulp_ansible.app import models, serializers as ansible_serializers
-from pulpcore.plugin.models import ContentArtifact, RepositoryVersion
+from pulpcore.plugin.models import ContentArtifact, RepositoryVersion, RepositoryContent
 from pulpcore.plugin import serializers as core_serializers
 
 
@@ -417,3 +417,41 @@ class CollectionVersionSearchListSerializer(CollectionVersionListSerializer):
             return obj.repository_version.number
         else:
             return "latest"
+
+
+class NamespaceSearchSerializer(serializers.ModelSerializer):
+    metadata = ansible_serializers.AnsibleNamespaceMetadataSerializer(source="content.ansible_ansiblenamespacemetadata")
+    repository_name = serializers.CharField(source="repository.name")
+
+
+    class Meta:
+        model = RepositoryContent
+        fields = (
+            "pk",
+            "metadata",
+            "repository_name",
+            # "has_latest_distro",
+            # "has_specific_distro",
+            # "version_added_num",
+            # "version_removed_num"
+        )
+
+
+    # debugging fields
+    # has_latest_distro = serializers.BooleanField()
+    # has_specific_distro = serializers.BooleanField()
+    # version_removed_num = serializers.SerializerMethodField()
+    # version_added_num = serializers.SerializerMethodField()
+
+
+    # def get_version_removed_num(self, obj):
+    #     if obj.version_removed:
+    #         return obj.version_removed.number
+
+    #     return None
+
+    # def get_version_added_num(self, obj):
+    #     if obj.version_added:
+    #         return obj.version_added.number
+
+    #     return None

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -420,38 +420,21 @@ class CollectionVersionSearchListSerializer(CollectionVersionListSerializer):
 
 
 class NamespaceSearchSerializer(serializers.ModelSerializer):
-    metadata = ansible_serializers.AnsibleNamespaceMetadataSerializer(source="content.ansible_ansiblenamespacemetadata")
-    repository_name = serializers.CharField(source="repository.name")
-
+    metadata = ansible_serializers.AnsibleNamespaceMetadataSerializer(
+        source="content.ansible_ansiblenamespacemetadata")
+    repository = core_serializers.RepositorySerializer()
+    in_latest_repo_version = serializers.SerializerMethodField()
+    in_old_repo_version = serializers.BooleanField()
 
     class Meta:
         model = RepositoryContent
         fields = (
-            "pk",
             "metadata",
-            "repository_name",
-            # "has_latest_distro",
-            # "has_specific_distro",
-            # "version_added_num",
-            # "version_removed_num"
+            "repository",
+            "in_latest_repo_version",
+            "in_old_repo_version",
         )
 
-
-    # debugging fields
-    # has_latest_distro = serializers.BooleanField()
-    # has_specific_distro = serializers.BooleanField()
-    # version_removed_num = serializers.SerializerMethodField()
-    # version_added_num = serializers.SerializerMethodField()
-
-
-    # def get_version_removed_num(self, obj):
-    #     if obj.version_removed:
-    #         return obj.version_removed.number
-
-    #     return None
-
-    # def get_version_added_num(self, obj):
-    #     if obj.version_added:
-    #         return obj.version_added.number
-
-    #     return None
+    @extend_schema_field(OpenApiTypes.BOOL)
+    def get_in_latest_repo_version(self, obj):
+        return obj.version_removed is None and obj.repo_has_latest_distro

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -421,7 +421,8 @@ class CollectionVersionSearchListSerializer(CollectionVersionListSerializer):
 
 class NamespaceSearchSerializer(serializers.ModelSerializer):
     metadata = ansible_serializers.AnsibleNamespaceMetadataSerializer(
-        source="content.ansible_ansiblenamespacemetadata")
+        source="content.ansible_ansiblenamespacemetadata"
+    )
     repository = core_serializers.RepositorySerializer()
     in_latest_repo_version = serializers.SerializerMethodField()
     in_old_repo_version = serializers.BooleanField()

--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -32,6 +32,7 @@ from pulpcore.plugin.models import (
 from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
 
 from .downloaders import AnsibleDownloaderFactory
+from .custom_fields import GroupModelPermissionsMixin
 
 
 log = getLogger(__name__)
@@ -113,12 +114,16 @@ class Tag(BaseModel):
         return self.name
 
 
-class AnsibleNamespace(BaseModel):
+class AnsibleNamespace(BaseModel, GroupModelPermissionsMixin):
     """
     A model representing a Namespace. This should be used for permissions.
     """
 
     name = models.CharField(max_length=64, unique=True, editable=True)
+
+    @property
+    def latest_metadata(self):
+        return self.metadatas.order_by("-pulp_created").first()
 
 
 class CollectionVersion(Content):

--- a/pulp_ansible/app/models.py
+++ b/pulp_ansible/app/models.py
@@ -32,7 +32,6 @@ from pulpcore.plugin.models import (
 from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
 
 from .downloaders import AnsibleDownloaderFactory
-from .custom_fields import GroupModelPermissionsMixin
 
 
 log = getLogger(__name__)
@@ -114,7 +113,7 @@ class Tag(BaseModel):
         return self.name
 
 
-class AnsibleNamespace(BaseModel, GroupModelPermissionsMixin):
+class AnsibleNamespace(BaseModel):
     """
     A model representing a Namespace. This should be used for permissions.
     """

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -815,10 +815,6 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
     """
     A serializer for Namespaces.
     """
-
-
-    # TODO: These two fields should be deprecated
-    related_fields = NamespaceRelatedFieldSerializer(source="*")
     groups = GroupPermissionField(source="namespace", allow_null=True, required=False)
 
     name = serializers.RegexField(
@@ -955,7 +951,6 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
             "avatar_sha256",
             "avatar_url",
             "metadata_sha256",
-            "related_fields",
             "groups"
         )
 
@@ -963,9 +958,10 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
 class AnsibleGlobalNamespaceSerializer(ModelSerializer, GetOrCreateSerializerMixin):
     pulp_href = IdentityField(view_name="pulp_ansible/namespaces-detail")
     latest_metadata = AnsibleNamespaceMetadataSerializer(read_only=True)
+    my_permissions = MyPermissionsField(source="*", read_only=True)
 
     class Meta:
-        fields = ModelSerializer.Meta.fields + ("name", "latest_metadata",)
+        fields = ModelSerializer.Meta.fields + ("name", "latest_metadata", "my_permissions")
         model = AnsibleNamespace
 
 

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -818,7 +818,7 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
 
     # TODO: These two fields should be deprecated
     related_fields = NamespaceRelatedFieldSerializer(source="*")
-    groups = GroupPermissionField(source="namespace.groups")
+    # groups = GroupPermissionField(source="namespace.groups")
 
     name = serializers.RegexField(
         NAME_REGEXP,
@@ -958,7 +958,7 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
             "avatar_url",
             "metadata_sha256",
             "related_fields",
-            "groups"
+            # "groups"
         )
 
 

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -811,7 +811,25 @@ class NamespaceRelatedFieldSerializer(RelatedFieldsBaseSerializer):
     my_permissions = MyPermissionsField(source="*", read_only=True)
 
 
-class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
+class NamespaceValidationMixin():
+    def validate_name(self, name):
+        if not name:
+            raise ValidationError(detail={
+                'name': _("Attribute 'name' is required")})
+        if not re.match(r'^[a-z0-9_]+$', name):
+            raise ValidationError(detail={
+                'name': _('Name can only contain lower case letters, underscores and numbers')})
+        if len(name) <= 2:
+            raise ValidationError(detail={
+                'name': _('Name must be longer than 2 characters')})
+        if name[0] in "0123456789_":
+            raise ValidationError(detail={
+                'name': _("Name cannot begin with '_' or any number")})
+
+        return name
+
+
+class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer, NamespaceValidationMixin):
     """
     A serializer for Namespaces.
     """
@@ -884,21 +902,6 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
                 data["avatar_sha256"] = avatar_artifact.sha256
 
         return super().validate(data)
-
-    def validate_name(self, name):
-        if not name:
-            raise ValidationError(detail={
-                'name': _("Attribute 'name' is required")})
-        if not re.match(r'^[a-z0-9_]+$', name):
-            raise ValidationError(detail={
-                'name': _('Name can only contain lower case letters, underscores and numbers')})
-        if len(name) <= 2:
-            raise ValidationError(detail={
-                'name': _('Name must be longer than 2 characters')})
-        if name.startswith('_'):
-            raise ValidationError(detail={
-                'name': _("Name cannot begin with '_'")})
-        return name
 
     @transaction.atomic
     def create(self, validated_data):
@@ -978,7 +981,7 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer):
         )
 
 
-class AnsibleGlobalNamespaceSerializer(ModelSerializer, GetOrCreateSerializerMixin):
+class AnsibleGlobalNamespaceSerializer(ModelSerializer, GetOrCreateSerializerMixin, NamespaceValidationMixin):
     pulp_href = IdentityField(view_name="pulp_ansible/namespaces-detail")
     latest_metadata = AnsibleNamespaceMetadataSerializer(read_only=True)
     my_permissions = MyPermissionsField(source="*", read_only=True)

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -61,7 +61,7 @@ from .custom_fields import (
     RelatedFieldsBaseSerializer,
     MyPermissionsField,
     GroupPermissionField,
-    set_object_group_roles
+    set_object_group_roles,
 )
 
 
@@ -811,20 +811,20 @@ class NamespaceRelatedFieldSerializer(RelatedFieldsBaseSerializer):
     my_permissions = MyPermissionsField(source="*", read_only=True)
 
 
-class NamespaceValidationMixin():
+class NamespaceValidationMixin:
     def validate_name(self, name):
         if not name:
-            raise ValidationError(detail={
-                'name': _("Attribute 'name' is required")})
-        if not re.match(r'^[a-z0-9_]+$', name):
-            raise ValidationError(detail={
-                'name': _('Name can only contain lower case letters, underscores and numbers')})
+            raise ValidationError(detail={"name": _("Attribute 'name' is required")})
+        if not re.match(r"^[a-z0-9_]+$", name):
+            raise ValidationError(
+                detail={
+                    "name": _("Name can only contain lower case letters, underscores and numbers")
+                }
+            )
         if len(name) <= 2:
-            raise ValidationError(detail={
-                'name': _('Name must be longer than 2 characters')})
+            raise ValidationError(detail={"name": _("Name must be longer than 2 characters")})
         if name[0] in "0123456789_":
-            raise ValidationError(detail={
-                'name': _("Name cannot begin with '_' or any number")})
+            raise ValidationError(detail={"name": _("Name cannot begin with '_' or any number")})
 
         return name
 
@@ -977,11 +977,13 @@ class AnsibleNamespaceMetadataSerializer(NoArtifactContentSerializer, NamespaceV
             "avatar_url",
             "metadata_sha256",
             "groups",
-            "task"
+            "task",
         )
 
 
-class AnsibleGlobalNamespaceSerializer(ModelSerializer, GetOrCreateSerializerMixin, NamespaceValidationMixin):
+class AnsibleGlobalNamespaceSerializer(
+    ModelSerializer, GetOrCreateSerializerMixin, NamespaceValidationMixin
+):
     pulp_href = IdentityField(view_name="pulp_ansible/namespaces-detail")
     latest_metadata = AnsibleNamespaceMetadataSerializer(read_only=True)
     my_permissions = MyPermissionsField(source="*", read_only=True)

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -252,11 +252,9 @@ v3_plugin_urls = [
     ),
     path(
         "search/namespace-metadata/",
-        views_v3.NamespaceMetadataSearchViewset.as_view(
-            {"get": "list"}
-        ),
+        views_v3.NamespaceMetadataSearchViewset.as_view({"get": "list"}),
         name="ansible-namespaces-search",
-    )
+    ),
 ]
 
 v3_urls = [

--- a/pulp_ansible/app/urls.py
+++ b/pulp_ansible/app/urls.py
@@ -250,6 +250,13 @@ v3_plugin_urls = [
         viewsets_v3.CollectionVersionSearchViewSet.as_view({"get": "list", "post": "rebuild"}),
         name="collection-versions-search",
     ),
+    path(
+        "search/namespace-metadata/",
+        views_v3.NamespaceMetadataSearchViewset.as_view(
+            {"get": "list"}
+        ),
+        name="ansible-namespaces-search",
+    )
 ]
 
 v3_urls = [

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -40,7 +40,7 @@ from pulpcore.plugin.util import (
     extract_pk,
     raise_for_unknown_content_units,
     get_objects_for_user,
-    get_artifact_url
+    get_artifact_url,
 )
 from pulp_ansible.app.galaxy.mixins import UploadGalaxyCollectionMixin
 from .models import (
@@ -378,8 +378,8 @@ class AnsibleNamespaceFilter(ContentFilter):
     # this is a hack to keep pulp from throwing a 400 when an unknwon
     # query param is included, since filtering is handled by the related
     # field serializer
-    include_related = filters.CharFilter(method='no_op')
-    my_permissions = filters.CharFilter(method='has_permissions')
+    include_related = filters.CharFilter(method="no_op")
+    my_permissions = filters.CharFilter(method="has_permissions")
 
     class Meta:
         model = AnsibleNamespaceMetadata
@@ -395,7 +395,8 @@ class AnsibleNamespaceFilter(ContentFilter):
     def has_permissions(self, queryset, name, value):
         perms = self.request.query_params.getlist(name)
         namespaces = get_objects_for_user(
-            self.request.user, perms, qs=AnsibleNamespace.objects.all())
+            self.request.user, perms, qs=AnsibleNamespace.objects.all()
+        )
         return self.queryset.filter(namespace__in=namespaces)
 
 
@@ -446,7 +447,8 @@ class AnsibleGlobalNamespaceFilter(BaseFilterSet):
     """
     A filter for namespaces.
     """
-    my_permissions = filters.CharFilter(method='has_permissions')
+
+    my_permissions = filters.CharFilter(method="has_permissions")
 
     class Meta:
         model = AnsibleNamespace
@@ -457,7 +459,8 @@ class AnsibleGlobalNamespaceFilter(BaseFilterSet):
     def has_permissions(self, queryset, name, value):
         perms = self.request.query_params.getlist(name)
         namespaces = get_objects_for_user(
-            self.request.user, perms, qs=AnsibleNamespace.objects.all())
+            self.request.user, perms, qs=AnsibleNamespace.objects.all()
+        )
         return self.queryset.filter(pk__in=namespaces)
 
 
@@ -478,6 +481,7 @@ class AnsibleGlobalNamespaceViewSet(
     serializer_class = AnsibleGlobalNamespaceSerializer
     filterset_class = AnsibleGlobalNamespaceFilter
 
+    # TODO: RBAC
     DEFAULT_ACCESS_POLICY = {
         "statements": [
             {
@@ -499,18 +503,6 @@ class AnsibleGlobalNamespaceViewSet(
         ],
     }
 
-
-
-
-
-    # TODO: How to handle delete?
-    # Can't delete if metadata exists, but namespaces should be able to deleted as
-    # long as no collections exist with them
-
-    # @extend_schema(
-    #     description="Trigger an asynchronous delete task",
-    #     responses={202: AsyncOperationResponseSerializer},
-    # )
     def destroy(self, request, *args, **kwargs):
         ns = self.get_object()
 

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -455,46 +455,35 @@ class AnsibleGlobalNamespaceViewSet(
     endpoint_name = "pulp_ansible/namespaces"
     queryset = AnsibleNamespace.objects.all()
     serializer_class = AnsibleGlobalNamespaceSerializer
+
+
+
+
+
+
+    # TODO
     # filterset_class = ContainerNamespaceFilter
 
-    # DEFAULT_ACCESS_POLICY = {
-    #     "statements": [
-    #         {
-    #             "action": ["list"],
-    #             "principal": "authenticated",
-    #             "effect": "allow",
-    #         },
-    #         {
-    #             "action": ["create"],
-    #             "principal": "authenticated",
-    #             "effect": "allow",
-    #             "condition": "has_model_perms:container.add_containernamespace",
-    #         },
-    #         {
-    #             "action": ["create"],
-    #             "principal": "authenticated",
-    #             "effect": "allow",
-    #             "condition": "namespace_is_username",
-    #         },
-    #         {
-    #             "action": ["retrieve", "my_permissions"],
-    #             "principal": "authenticated",
-    #             "effect": "allow",
-    #             "condition": "has_model_or_obj_perms:container.view_containernamespace",
-    #         },
-    #         {
-    #             "action": ["destroy"],
-    #             "principal": "authenticated",
-    #             "effect": "allow",
-    #             "condition": [
-    #                 "has_model_or_obj_perms:container.delete_containernamespace",
-    #                 "has_model_or_obj_perms:container.view_containernamespace",
-    #             ],
-    #         },
-    #     ],
-    #     "creation_hooks": [],
-    #     "queryset_scoping": {"function": "scope_queryset"},
-    # }
+    DEFAULT_ACCESS_POLICY = {
+        "statements": [
+            {
+                "action": "*",
+                "principal": "authenticated",
+                "effect": "allow",
+            }
+        ],
+        "creation_hooks": [],
+        "queryset_scoping": {"function": "scope_queryset"},
+    }
+
+    LOCKED_ROLES = {
+        "ansible.namespace_owner": [
+            "ansible.view_ansiblenamespace",
+            "ansible.change_ansiblenamespace",
+            "ansible.delete_ansiblenamespace",
+            # "ansible.manage_roles_ansiblenamespace",
+        ],
+    }
 
 
 

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -440,6 +440,25 @@ class AnsibleNamespaceViewSet(ReadOnlyContentViewSet):
         return HttpResponseNotFound()
 
 
+class AnsibleGlobalNamespaceFilter(ContentFilter):
+    """
+    A filter for namespaces.
+    """
+    my_permissions = filters.CharFilter(method='has_permissions')
+
+    class Meta:
+        model = AnsibleNamespace
+        fields = {
+            "name": NAME_FILTER_OPTIONS,
+        }
+
+    def has_permissions(self, queryset, name, value):
+        perms = self.request.query_params.getlist(name)
+        namespaces = get_objects_for_user(
+            self.request.user, perms, qs=AnsibleNamespace.objects.all())
+        return self.queryset.filter(pk__in=namespaces)
+
+
 class AnsibleGlobalNamespaceViewSet(
     NamedModelViewSet,
     mixins.CreateModelMixin,
@@ -455,14 +474,7 @@ class AnsibleGlobalNamespaceViewSet(
     endpoint_name = "pulp_ansible/namespaces"
     queryset = AnsibleNamespace.objects.all()
     serializer_class = AnsibleGlobalNamespaceSerializer
-
-
-
-
-
-
-    # TODO
-    # filterset_class = ContainerNamespaceFilter
+    filterset_class = AnsibleGlobalNamespaceFilter
 
     DEFAULT_ACCESS_POLICY = {
         "statements": [

--- a/pulp_ansible/tests/functional/api/collection/v3/test_namespace.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_namespace.py
@@ -7,30 +7,8 @@ import string
 import numpy as np
 from PIL import Image
 
-
-
-
-
-
-"""
-New tests:
-- v3/namespaces
-    - groups
-    - split create/add to repo
-    - error messages
-    - namespace name validation
-- search/namespace-metadata
-    - filters
-    - verify only items in distributions are returned
-- pulp_ansible/namespaces
-    - My permissions (filter and field)
-    - latest metadata
-    - CRUD
-    - role management
-"""
-
-
-
+from pulpcore.client.pulp_ansible.exceptions import ApiException, ApiValueError
+from pulp_ansible.tests.functional.utils import iterate_all
 
 
 def random_string(n=10):
@@ -64,6 +42,327 @@ def random_image_factory(tmp_path):
         return path
 
     return _random_image
+
+
+def test_invalid_namespace_names(
+    ansible_repo_and_distro_factory,
+    galaxy_v3_plugin_namespaces_api_client,
+    global_ansible_namespaces_api_client
+):
+    """Test that users can't create namespaces with invalid names."""
+    repo, distro = ansible_repo_and_distro_factory()
+    kwargs = {"path": distro.base_path, "distro_base_path": distro.base_path}
+
+    invalid_names = [
+        "",
+        "_hello_world",
+        "123345",
+        "2cool4school",
+        "x",
+        "xy",
+        "my-namespace-name",
+        "my.namespace.name",
+        "hello!",
+    ]
+
+    for name in invalid_names:
+        try:
+            global_ansible_namespaces_api_client.create({"name": name})
+        except ApiException as e:
+            assert "name" in e.body
+        except ApiValueError as e:
+            assert "name" in str(e)
+        else:
+            assert not f"User was able to create global namespace with invalid name {name}"
+
+        try:
+            galaxy_v3_plugin_namespaces_api_client.create(
+                name=name, **kwargs
+            )
+        except ApiException as e:
+            assert "name" in e.body
+        except ApiValueError as e:
+            assert "name" in str(e)
+        else:
+            assert not f"User was able to create namespace metadata with invalid name {name}"
+
+
+def test_namespace_groups(
+    ansible_repo_and_distro_factory,
+    galaxy_v3_plugin_namespaces_api_client,
+    groups_api_client,
+    monitor_task,
+):
+    """
+    Test that the legacy groups field works.
+    """
+
+    group_1 = random_string()
+    group_2 = random_string()
+
+    groups_api_client.create({"name": group_1})
+    groups_api_client.create({"name": group_2})
+
+    repo, distro = ansible_repo_and_distro_factory()
+    kwargs = {"path": distro.base_path, "distro_base_path": distro.base_path}
+
+    # Create namespace with no groups
+    name = random_string()
+    result = galaxy_v3_plugin_namespaces_api_client.create(
+        name=name, **kwargs
+    )
+    monitor_task(result.task)
+
+    v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
+    assert v3_namespace.groups == []
+
+    group_1_mapping = {
+        "name": group_1,
+        "object_roles": ["ansible.namespace_owner"],
+    }
+
+    group_2_mapping = {
+        "name": group_2,
+        "object_roles": ["ansible.namespace_owner"],
+    }
+
+    # Create namespace with groups
+    name = random_string()
+    result = galaxy_v3_plugin_namespaces_api_client.create(
+        name=name, groups=[group_1_mapping, ], **kwargs
+    )
+    monitor_task(result.task)
+    v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
+    assert {x.name for x in v3_namespace.groups} == {group_1}
+
+    # Verify partial update doesn't remove groups
+    result = galaxy_v3_plugin_namespaces_api_client.partial_update(
+        name=name, description="foo", **kwargs
+    )
+    monitor_task(result.task)
+    v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
+    assert {x.name for x in v3_namespace.groups} == {group_1}
+
+    # Add an extra group
+    result = galaxy_v3_plugin_namespaces_api_client.partial_update(
+        name=name, groups=[group_1_mapping, group_2_mapping,], **kwargs
+    )
+    monitor_task(result.task)
+    v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
+    assert {x.name for x in v3_namespace.groups} == {group_1, group_2}
+
+    # Remove groups
+    result = galaxy_v3_plugin_namespaces_api_client.partial_update(
+        name=name, groups=[], **kwargs
+    )
+    monitor_task(result.task)
+    v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
+    assert v3_namespace.groups == []
+
+
+def test_namespace_metadata_search(
+    ansible_repo_and_distro_factory,
+    galaxy_v3_plugin_namespaces_api_client,
+    monitor_task,
+    ansible_namespace_search_api_client,
+    ansible_repo_api_client,
+    ansible_distro_api_client
+):
+    """
+    Test that the namespaces search API is returning all the distributed namespace
+    metadata content.
+    """
+    repo1, distro1 = ansible_repo_and_distro_factory()
+    repo2, distro2 = ansible_repo_and_distro_factory()
+
+    repo1_namespaces = [random_string() for x in range(3)]
+    repo2_namespaces = [random_string() for x in range(3)]
+    shared_ns = [random_string() for x in range(3)]
+
+    def _tupleify(namespaces, repos):
+        content_set = set()
+
+        for ns in namespaces:
+            for r in repos:
+                content_set.add((r.name, ns))
+
+        return content_set
+
+    # populate two repositories with a set of shared and unique namespaces
+    for name in repo1_namespaces + shared_ns:
+        kwargs = {"path": distro1.base_path, "distro_base_path": distro1.base_path}
+        result = galaxy_v3_plugin_namespaces_api_client.create(
+            name=name, **kwargs
+        )
+        monitor_task(result.task)
+
+    for name in repo2_namespaces + shared_ns:
+        kwargs = {"path": distro2.base_path, "distro_base_path": distro2.base_path}
+        result = galaxy_v3_plugin_namespaces_api_client.create(
+            name=name, **kwargs
+        )
+        monitor_task(result.task)
+
+    repo1_set = _tupleify(shared_ns + repo1_namespaces, [repo1])
+    repo2_set = _tupleify(shared_ns + repo2_namespaces, [repo2])
+
+    # test that the namespaces from every repo with a distribution are returned
+    search_results = set()
+
+    for ns in iterate_all(ansible_namespace_search_api_client.list):
+        search_results.add((ns.repository.name, ns.metadata.name))
+        assert ns.in_latest_repo_version
+        assert not ns.in_old_repo_version
+
+    assert search_results == repo1_set | repo2_set
+
+    # add a new distro pointing to a specific repository version of the first repo
+    task = ansible_distro_api_client.create({
+        "base_path": random_string(),
+        "name": random_string(),
+        "repository_version": ansible_repo_api_client.read(repo1.pulp_href).latest_version_href
+    })
+
+    new_distro_href = monitor_task(task.task).created_resources[0]
+
+    # The number of results should be unchanged
+    assert len(search_results) == ansible_namespace_search_api_client.list().count
+
+    # Contents of repo1 should be marked as in latest and old repo version
+    for ns in iterate_all(ansible_namespace_search_api_client.list, repository_name=repo1.name):
+        assert ns.in_latest_repo_version
+        assert not ns.in_old_repo_version
+
+    # Remove a namespace from the first repo
+    removed_namespace = repo1_namespaces.pop()
+    repo1_set = _tupleify(shared_ns + repo1_namespaces, [repo1])
+
+    kwargs = {"path": distro1.base_path, "distro_base_path": distro1.base_path}
+    monitor_task(
+        galaxy_v3_plugin_namespaces_api_client.delete(name=removed_namespace, **kwargs).task)
+
+    # Contents of repo1 should be marked as in latest and old repo version
+    for ns in iterate_all(ansible_namespace_search_api_client.list, repository_name=repo1.name):
+        if ns.metadata.name != removed_namespace:
+            assert ns.in_latest_repo_version
+            assert not ns.in_old_repo_version
+        else:
+            # namespace that was removed from latest version should no longer be marked
+            # as in latest
+            assert not ns.in_latest_repo_version
+            assert ns.in_old_repo_version
+
+    # Since there's still a distro pointing to the old repo version, the number of
+    # results should be unchanged
+    old_count = ansible_namespace_search_api_client.list().count
+    assert len(search_results) == old_count
+
+    # Delete the new distro
+    monitor_task(ansible_distro_api_client.delete(new_distro_href).task)
+
+    # The removed namespace should no longer appear in the search now that the distro that it
+    # was in has been deleted
+    search_results = {
+        (x.repository.name, x.metadata.name) for x in iterate_all(
+            ansible_namespace_search_api_client.list)
+    }
+
+    assert search_results == repo1_set | repo2_set
+    assert ansible_namespace_search_api_client.list().count == old_count - 1
+
+    # Delete distro1
+    monitor_task(ansible_distro_api_client.delete(distro1.pulp_href).task)
+
+    # The content in distro1 should be removed from the search results
+    search_results = {
+        (x.repository.name, x.metadata.name) for x in iterate_all(
+            ansible_namespace_search_api_client.list)
+    }
+
+    assert search_results == repo2_set
+
+
+def test_global_namespaces_latest_metadata(
+    global_ansible_namespaces_api_client,
+    ansible_repo_and_distro_factory,
+    galaxy_v3_plugin_namespaces_api_client,
+    monitor_task,
+):
+    """
+    Test that the latest metadata field is updated on the global namespace api
+    """
+
+    repo, distro = ansible_repo_and_distro_factory()
+    kwargs = {"path": distro.base_path, "distro_base_path": distro.base_path}
+
+    # Create namespace with v3 api
+    name = random_string()
+    description = "ns 1"
+    result = galaxy_v3_plugin_namespaces_api_client.create(
+        name=name, description=description, **kwargs
+    )
+    monitor_task(result.task)
+
+    # test that the latest_namespace field is updated on the global namespace api
+    g_ns = global_ansible_namespaces_api_client.list(name=name).results[0]
+    assert g_ns.latest_metadata.description == description
+
+    description = "ns 2"
+    result = galaxy_v3_plugin_namespaces_api_client.partial_update(
+        name=name, description=description, **kwargs
+    )
+    monitor_task(result.task)
+
+    g_ns = global_ansible_namespaces_api_client.list(name=name).results[0]
+    assert g_ns.latest_metadata.description == description
+
+    # verify namespaces with metadata can't be deleted
+    try:
+        global_ansible_namespaces_api_client.delete(g_ns.pulp_href)
+    except ApiException as e:
+        assert "cannot be deleted" in e.body
+    else:
+        assert not "User's should not be able to delete namespaces with namespace metadata"
+
+
+def test_global_namespaces_latest_crud(
+    global_ansible_namespaces_api_client,
+    ansible_repo_and_distro_factory,
+    galaxy_v3_plugin_namespaces_api_client,
+    monitor_task,
+    gen_user
+):
+    ns_owner = gen_user()
+
+    # Create the namespace
+    name = random_string()
+    global_ansible_namespaces_api_client.create({"name": name})
+    g_ns = global_ansible_namespaces_api_client.list(name=name).results[0]
+    assert g_ns.name == name
+
+    # test my permissions filter
+    with ns_owner:
+        assert global_ansible_namespaces_api_client.list(
+            name=name, my_permissions="ansible.change_ansiblenamespace").count == 0
+
+    global_ansible_namespaces_api_client.add_role(
+        g_ns.pulp_href,
+        {
+            "users": [ns_owner.user.username, ],
+            "role": "ansible.namespace_owner"
+        }
+    )
+
+    # test my permissions filter
+    with ns_owner:
+        results = global_ansible_namespaces_api_client.list(
+            name=name, my_permissions="ansible.change_ansiblenamespace")
+
+        assert results.count == 1
+        assert "ansible.change_ansiblenamespace" in results.results[0].my_permissions
+
+    global_ansible_namespaces_api_client.delete(g_ns.pulp_href)
+    assert global_ansible_namespaces_api_client.list(name=name).count == 0
 
 
 def test_crud_namespaces(

--- a/pulp_ansible/tests/functional/api/collection/v3/test_namespace.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_namespace.py
@@ -47,7 +47,7 @@ def random_image_factory(tmp_path):
 def test_invalid_namespace_names(
     ansible_repo_and_distro_factory,
     galaxy_v3_plugin_namespaces_api_client,
-    global_ansible_namespaces_api_client
+    global_ansible_namespaces_api_client,
 ):
     """Test that users can't create namespaces with invalid names."""
     repo, distro = ansible_repo_and_distro_factory()
@@ -76,9 +76,7 @@ def test_invalid_namespace_names(
             assert not f"User was able to create global namespace with invalid name {name}"
 
         try:
-            galaxy_v3_plugin_namespaces_api_client.create(
-                name=name, **kwargs
-            )
+            galaxy_v3_plugin_namespaces_api_client.create(name=name, **kwargs)
         except ApiException as e:
             assert "name" in e.body
         except ApiValueError as e:
@@ -108,9 +106,7 @@ def test_namespace_groups(
 
     # Create namespace with no groups
     name = random_string()
-    result = galaxy_v3_plugin_namespaces_api_client.create(
-        name=name, **kwargs
-    )
+    result = galaxy_v3_plugin_namespaces_api_client.create(name=name, **kwargs)
     monitor_task(result.task)
 
     v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
@@ -129,7 +125,11 @@ def test_namespace_groups(
     # Create namespace with groups
     name = random_string()
     result = galaxy_v3_plugin_namespaces_api_client.create(
-        name=name, groups=[group_1_mapping, ], **kwargs
+        name=name,
+        groups=[
+            group_1_mapping,
+        ],
+        **kwargs,
     )
     monitor_task(result.task)
     v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
@@ -145,16 +145,19 @@ def test_namespace_groups(
 
     # Add an extra group
     result = galaxy_v3_plugin_namespaces_api_client.partial_update(
-        name=name, groups=[group_1_mapping, group_2_mapping,], **kwargs
+        name=name,
+        groups=[
+            group_1_mapping,
+            group_2_mapping,
+        ],
+        **kwargs,
     )
     monitor_task(result.task)
     v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
     assert {x.name for x in v3_namespace.groups} == {group_1, group_2}
 
     # Remove groups
-    result = galaxy_v3_plugin_namespaces_api_client.partial_update(
-        name=name, groups=[], **kwargs
-    )
+    result = galaxy_v3_plugin_namespaces_api_client.partial_update(name=name, groups=[], **kwargs)
     monitor_task(result.task)
     v3_namespace = galaxy_v3_plugin_namespaces_api_client.read(name=name, **kwargs)
     assert v3_namespace.groups == []
@@ -166,7 +169,7 @@ def test_namespace_metadata_search(
     monitor_task,
     ansible_namespace_search_api_client,
     ansible_repo_api_client,
-    ansible_distro_api_client
+    ansible_distro_api_client,
 ):
     """
     Test that the namespaces search API is returning all the distributed namespace
@@ -191,16 +194,12 @@ def test_namespace_metadata_search(
     # populate two repositories with a set of shared and unique namespaces
     for name in repo1_namespaces + shared_ns:
         kwargs = {"path": distro1.base_path, "distro_base_path": distro1.base_path}
-        result = galaxy_v3_plugin_namespaces_api_client.create(
-            name=name, **kwargs
-        )
+        result = galaxy_v3_plugin_namespaces_api_client.create(name=name, **kwargs)
         monitor_task(result.task)
 
     for name in repo2_namespaces + shared_ns:
         kwargs = {"path": distro2.base_path, "distro_base_path": distro2.base_path}
-        result = galaxy_v3_plugin_namespaces_api_client.create(
-            name=name, **kwargs
-        )
+        result = galaxy_v3_plugin_namespaces_api_client.create(name=name, **kwargs)
         monitor_task(result.task)
 
     repo1_set = _tupleify(shared_ns + repo1_namespaces, [repo1])
@@ -217,11 +216,13 @@ def test_namespace_metadata_search(
     assert search_results == repo1_set | repo2_set
 
     # add a new distro pointing to a specific repository version of the first repo
-    task = ansible_distro_api_client.create({
-        "base_path": random_string(),
-        "name": random_string(),
-        "repository_version": ansible_repo_api_client.read(repo1.pulp_href).latest_version_href
-    })
+    task = ansible_distro_api_client.create(
+        {
+            "base_path": random_string(),
+            "name": random_string(),
+            "repository_version": ansible_repo_api_client.read(repo1.pulp_href).latest_version_href,
+        }
+    )
 
     new_distro_href = monitor_task(task.task).created_resources[0]
 
@@ -239,7 +240,8 @@ def test_namespace_metadata_search(
 
     kwargs = {"path": distro1.base_path, "distro_base_path": distro1.base_path}
     monitor_task(
-        galaxy_v3_plugin_namespaces_api_client.delete(name=removed_namespace, **kwargs).task)
+        galaxy_v3_plugin_namespaces_api_client.delete(name=removed_namespace, **kwargs).task
+    )
 
     # Contents of repo1 should be marked as in latest and old repo version
     for ns in iterate_all(ansible_namespace_search_api_client.list, repository_name=repo1.name):
@@ -263,8 +265,8 @@ def test_namespace_metadata_search(
     # The removed namespace should no longer appear in the search now that the distro that it
     # was in has been deleted
     search_results = {
-        (x.repository.name, x.metadata.name) for x in iterate_all(
-            ansible_namespace_search_api_client.list)
+        (x.repository.name, x.metadata.name)
+        for x in iterate_all(ansible_namespace_search_api_client.list)
     }
 
     assert search_results == repo1_set | repo2_set
@@ -275,8 +277,8 @@ def test_namespace_metadata_search(
 
     # The content in distro1 should be removed from the search results
     search_results = {
-        (x.repository.name, x.metadata.name) for x in iterate_all(
-            ansible_namespace_search_api_client.list)
+        (x.repository.name, x.metadata.name)
+        for x in iterate_all(ansible_namespace_search_api_client.list)
     }
 
     assert search_results == repo2_set
@@ -330,7 +332,7 @@ def test_global_namespaces_latest_crud(
     ansible_repo_and_distro_factory,
     galaxy_v3_plugin_namespaces_api_client,
     monitor_task,
-    gen_user
+    gen_user,
 ):
     ns_owner = gen_user()
 
@@ -342,21 +344,28 @@ def test_global_namespaces_latest_crud(
 
     # test my permissions filter
     with ns_owner:
-        assert global_ansible_namespaces_api_client.list(
-            name=name, my_permissions="ansible.change_ansiblenamespace").count == 0
+        assert (
+            global_ansible_namespaces_api_client.list(
+                name=name, my_permissions="ansible.change_ansiblenamespace"
+            ).count
+            == 0
+        )
 
     global_ansible_namespaces_api_client.add_role(
         g_ns.pulp_href,
         {
-            "users": [ns_owner.user.username, ],
-            "role": "ansible.namespace_owner"
-        }
+            "users": [
+                ns_owner.user.username,
+            ],
+            "role": "ansible.namespace_owner",
+        },
     )
 
     # test my permissions filter
     with ns_owner:
         results = global_ansible_namespaces_api_client.list(
-            name=name, my_permissions="ansible.change_ansiblenamespace")
+            name=name, my_permissions="ansible.change_ansiblenamespace"
+        )
 
         assert results.count == 1
         assert "ansible.change_ansiblenamespace" in results.results[0].my_permissions

--- a/pulp_ansible/tests/functional/conftest.py
+++ b/pulp_ansible/tests/functional/conftest.py
@@ -31,6 +31,8 @@ from pulpcore.client.pulp_ansible import (
     PulpAnsibleApiV3PluginAnsibleContentNamespacesApi,
     PulpAnsibleDefaultApiV3PluginAnsibleContentCollectionsIndexApi,
     PulpAnsibleDefaultApiV3PluginAnsibleSearchCollectionVersionsApi,
+    PulpAnsibleNamespacesApi,
+    PulpAnsibleDefaultApiV3PluginAnsibleSearchNamespaceMetadataApi,
 )
 
 
@@ -121,6 +123,18 @@ def ansible_remote_role_api_client(ansible_bindings_client):
 def ansible_remote_git_api_client(ansible_bindings_client):
     """Provides the Ansible Git Remotes API client object."""
     return RemotesGitApi(ansible_bindings_client)
+
+
+@pytest.fixture
+def global_ansible_namespaces_api_client(ansible_bindings_client):
+    """Provides the Ansible Content Namespaces API client object."""
+    return PulpAnsibleNamespacesApi(ansible_bindings_client)
+
+
+@pytest.fixture
+def ansible_namespace_search_api_client(ansible_bindings_client):
+    """Provides the Ansible Content Namespaces API client object."""
+    return PulpAnsibleDefaultApiV3PluginAnsibleSearchNamespaceMetadataApi(ansible_bindings_client)
 
 
 @pytest.fixture


### PR DESCRIPTION
Added:
- `/v3/plugin/ansible/search/namespace-metadata/` -> provides cross repo search functionality for namespace metadata
- `/pulp/api/v3/pulp_ansible/namespaces/` -> API for creating, updating permissions and viewing pulp ansible global namespace

Changed:
- `/v3/namespaces/` -> make the API backwards compatible with galaxy_ng

Jira ticket: https://issues.redhat.com/browse/AAH-2293 (github issue comming soon)

Todo:
- [x] Add filtersets on new APIs
- [x] Tests
- [ ] RBAC
- [ ] v3 compatiblity
    - [ ] error messages
    - [x] filters
    - [ ] allow saving an image with an avatar URL
    - [x] save namespace metadata before launching task to add it to repository