### PR TITLE
Fix sphinx intersphinx_mapping config.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,4 +173,4 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"python": ('https://docs.python.org/', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
```
# make PULP_URL="$PULP_URL" html
sphinx-build -b html -d _build/doctrees  -W -n . _build/html
Running Sphinx v7.0.0

Warning, treated as error:
Failed to read intersphinx_mapping[https://docs.python.org/], ignored: SphinxWarning('The pre-Sphinx 1.0 \'intersphinx_mapping\' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {\'<name>\': (\'https://docs.python.org/\', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping')
make: *** [Makefile:63: html] Error 2
```

New value comes from https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration

[noissue]