### PR TITLE
Gracefully skip download counter increment if database is read-only.

### DIFF
--- a/CHANGES/1491.bugfix
+++ b/CHANGES/1491.bugfix
@@ -1,0 +1,1 @@
+Wrapped db writes with try/except for collection download logs with read-only databases.


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2416
https://issues.redhat.com/browse/AAH-2333

https://github.com/pulp/pulp_ansible/issues/1491