### PR TITLE
Fix import export test exception.

### DIFF
--- a/pulp_ansible/tests/functional/api/test_export_import.py
+++ b/pulp_ansible/tests/functional/api/test_export_import.py
@@ -79,7 +79,9 @@ def test_export_then_import(
     assert export.output_file_info is not None
     for an_export_filename in export.output_file_info.keys():
         assert "//" not in an_export_filename
-    export_filename = next(f for f in export.output_file_info.keys() if f.endswith("tar.gz"))
+    export_filename = next(
+        f for f in export.output_file_info.keys() if f.endswith("tar.gz") or f.endswith("tar")
+    )
 
     # Prepare import
     repo_c = ansible_repo_factory()


### PR DESCRIPTION
Due to https://github.com/pulp/pulpcore/pull/4477 export now produces tars instead of tar.gz ...

```
        # Export
        task = exporters_pulp_exports_api_client.create(exporter.pulp_href, {}).task
        task = monitor_task(task)
        assert len(task.created_resources) == 1
        export = exporters_pulp_exports_api_client.read(task.created_resources[0])
        assert export is not None
        assert len(exporter.repositories) == len(export.exported_resources)
        assert export.output_file_info is not None
        for an_export_filename in export.output_file_info.keys():
            assert "//" not in an_export_filename
>       export_filename = next(f for f in export.output_file_info.keys() if f.endswith("tar.gz"))
E       StopIteration
```