### PR TITLE
Fix a uniqueness violation for is_highest

### DIFF
--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -1220,5 +1220,6 @@ class AnsibleContentSaver(ContentSaver):
                         continue
                     setattr(collection_version, attr_name, attr_value)
 
+                collection_version.is_highest = False
                 collection_version.save()
                 _update_highest_version(collection_version)


### PR DESCRIPTION
When syncing content, we need to ignore the upstream status of is_highest.

[noissue]