### PR TITLE
Fix cli usage in docs testing

### DIFF
--- a/docs/_scripts/setup.sh
+++ b/docs/_scripts/setup.sh
@@ -17,5 +17,7 @@ if [ ! -f ~/.config/pulp/settings.toml ]; then
 base_url = "$BASE_ADDR"
 verify_ssl = false
 format = "json"
+username = "admin"
+password = "password"
 EOF
 fi


### PR DESCRIPTION
Add values for username and password that are not provided by default anymore.

[noissue]