### PR TITLE
Add ansible api hostname to api cache key.

### DIFF
--- a/CHANGES/1833.bugfix
+++ b/CHANGES/1833.bugfix
@@ -1,0 +1,1 @@
+Add ansible hostname to API v3 cache key


### PR DESCRIPTION
We're looking into switching galaxy_ng to generate the `ANSIBLE_API_HOSTNAME` dynamically in order to support hosting from multiple URLs. The cached API responses were causing this to break.

Fixes #1833 