### PR TITLE
Cast the content object to a collection version when rebuilding meta.

### DIFF
--- a/CHANGES/1921.bugfix
+++ b/CHANGES/1921.bugfix
@@ -1,0 +1,1 @@
+Cast the content object to a collectionversion before setting the rebuild metadata.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -384,10 +384,14 @@ def rebuild_repository_collection_versions_metadata(
             ptotal.increment()
 
 
-def _rebuild_collection_version_meta(collection_version):
+def _rebuild_collection_version_meta(content_object):
     """Rebuild metadata for a single collection version."""
+
+    # Cast to get the CV
+    collection_version = content_object.cast()
+
     # where is the artifact?
-    artifact = collection_version._artifacts.first()
+    artifact = content_object._artifacts.first()
 
     # call the importer to re-generate meta
     importer_result = process_collection(

--- a/pulp_ansible/tests/unit/test_tasks.py
+++ b/pulp_ansible/tests/unit/test_tasks.py
@@ -101,6 +101,25 @@ class TestCollectionReImport(TestCase):
         expected_pks = sorted([str(x.pk) for x in expected_cvs])
         assert call_pks == expected_pks
 
+    def test_reimport_repository_rebuilds_contents(self):
+        """Make sure the contents field in the CVs are rebuilt."""
+
+        cobject = self.repo.latest_version().content.first()
+        assert cobject is not None, "the repo fixture no longer has content for some unknown reason"
+
+        # set some invalid contents for each CV in the repo ...
+        cv = cobject.cast()
+        cv.contents = ["a", "b", "c"]
+        cv.save()
+
+        # call the rebuild
+        _rebuild_collection_version_meta(cobject)
+
+        # after rebuild, the contents should have been changed back
+        cv2 = cobject.cast()
+        cv2.refresh_from_db()
+        assert cv2.contents != ["a", "b", "c"]
+
 
 class TestCollectionVersionHighest(TestCase):
     """Test Collection Re-Import."""


### PR DESCRIPTION
The incoming object is a content object, not a collectionversion so setting the fields and saving them is a NO-OP. We have to cast() to get the right object to manipulate the relevant fields.

fixes #1921