### PR TITLE
Fix some 500 errors in the galaxy api

### DIFF
--- a/CHANGES/galaxy500s.bugfix
+++ b/CHANGES/galaxy500s.bugfix
@@ -1,0 +1,1 @@
+Fixed some 500 errors when browsing the Galaxy API.

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -142,7 +142,7 @@ class AnsibleDistributionMixin:
 
         repo_version = distro.repository.latest_version() if distro.repository else None
         self.pulp_context = {path: repo_version}
-        self._repo = distro.repository.ansible_ansiblerepository
+        self._repo = repo_version.repository.cast() if repo_version else None
         self._repo_version = repo_version
         return repo_version
 

--- a/pulp_ansible/app/settings.py
+++ b/pulp_ansible/app/settings.py
@@ -20,6 +20,11 @@ LOGGING = {
     "dynaconf_merge": True,
 }
 
+DRF_ACCESS_POLICY = {
+    "dynaconf_merge_unique": True,
+    "reusable_conditions": ["pulp_ansible.app.global_access_conditions"],
+}
+
 ANSIBLE_API_HOSTNAME = "https://" + socket.getfqdn()
 ANSIBLE_CONTENT_HOSTNAME = settings.CONTENT_ORIGIN + "/pulp/content"
 ANSIBLE_SIGNATURE_REQUIRE_VERIFICATION = True
@@ -30,8 +35,3 @@ ANSIBLE_COLLECT_DOWNLOAD_LOG = False
 ANSIBLE_COLLECT_DOWNLOAD_COUNT = False
 ANSIBLE_AUTHENTICATION_CLASSES = settings.REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]
 ANSIBLE_PERMISSION_CLASSES = settings.REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"]
-
-DRF_ACCESS_POLICY = {
-    "dynaconf_merge_unique": True,
-    "reusable_conditions": ["pulp_ansible.app.global_access_conditions"],
-}


### PR DESCRIPTION
Moving the DRF_ACCESS_POLICY in the settings file fixes an error in the Pulp image where the setting doesn't get loaded for pulp_ansible. The second fix is for when you are browsing an empty distribution.