### PR TITLE
Fix latest_version_modified annotation.

### DIFF
--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -5,7 +5,6 @@ import base64
 
 from django.db import DatabaseError, IntegrityError
 from django.db.models import F, OuterRef, Exists, Subquery, Prefetch
-from django.db.models.functions import Greatest
 from django.http import StreamingHttpResponse, HttpResponseNotFound
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.dateparse import parse_datetime
@@ -31,7 +30,6 @@ from pulpcore.plugin.models import (
     Artifact,
     Content,
     ContentArtifact,
-    RepositoryContent,
     Distribution,
 )
 from pulpcore.plugin.serializers import AsyncOperationResponseSerializer

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -335,24 +335,6 @@ class CollectionViewSet(
             .only("version")
         )
 
-        latest_version_modified_qs = (
-            RepositoryContent.objects.filter(
-                repository_id=repo_version.repository_id,
-                version_added__number__lte=repo_version.number,
-            )
-            .select_related("content__ansible_collectionversion")
-            .select_related("version_added")
-            .select_related("version_removed")
-            .filter(content__ansible_collectionversion__collection_id=OuterRef("pk"))
-            .annotate(
-                last_updated=Greatest(
-                    "version_added__pulp_created", "version_removed__pulp_created"
-                )
-            )
-            .order_by("-last_updated")
-            .only("last_updated")
-        )
-
         download_count_qs = CollectionDownloadCount.objects.filter(
             name=OuterRef("name"), namespace=OuterRef("namespace")
         )
@@ -360,9 +342,7 @@ class CollectionViewSet(
         qs = (
             Collection.objects.annotate(
                 highest_version=Subquery(latest_cv_version_qs.values("version")[:1]),
-                latest_version_modified=Subquery(
-                    latest_version_modified_qs.values("last_updated")[:1]
-                ),
+                latest_version_modified=Subquery(latest_cv_version_qs.values("pulp_last_updated")[:1]),
             )
             .annotate(
                 deprecated=Exists(deprecated_qs),

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -342,7 +342,9 @@ class CollectionViewSet(
         qs = (
             Collection.objects.annotate(
                 highest_version=Subquery(latest_cv_version_qs.values("version")[:1]),
-                latest_version_modified=Subquery(latest_cv_version_qs.values("pulp_last_updated")[:1]),
+                latest_version_modified=Subquery(
+                    latest_cv_version_qs.values("pulp_last_updated")[:1]
+                ),
             )
             .annotate(
                 deprecated=Exists(deprecated_qs),

--- a/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
@@ -1,7 +1,5 @@
 """Tests related to Galaxy V3 serializers."""
 
-import yaml
-
 from pulpcore.client.pulp_ansible import (
     AnsibleRepositorySyncURL,
     ContentCollectionVersionsApi,
@@ -64,7 +62,6 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
         original_highest_version = collections.data[0].highest_version["version"]
         original_updated_at = collections.data[0].updated_at
 
-        versions = self.collections_versions_api.list(version="0.0.7")
         original_total_versions = self.collections_versions_v3api.list(
             "squeezer", "pulp", distribution.base_path
         ).meta.count

--- a/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
+++ b/pulp_ansible/tests/functional/api/collection/v3/test_serializers.py
@@ -1,6 +1,9 @@
 """Tests related to Galaxy V3 serializers."""
 
+import yaml
+
 from pulpcore.client.pulp_ansible import (
+    AnsibleRepositorySyncURL,
     ContentCollectionVersionsApi,
     DistributionsAnsibleApi,
     PulpAnsibleApiV3CollectionsApi,
@@ -12,6 +15,7 @@ from pulp_smash.pulp3.bindings import monitor_task
 
 from pulp_ansible.tests.functional.utils import SyncHelpersMixin, TestCaseUsingBindings
 from pulp_ansible.tests.functional.utils import gen_ansible_client, gen_ansible_remote
+from pulp_ansible.tests.functional.utils import tasks
 
 
 class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
@@ -30,9 +34,23 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
 
     def test_v3_updated_at(self):
         """Test Collections V3 endpoint field: ``updated_at``."""
+
+        requirements1 = """
+        collections:
+            - name: "pulp.squeezer"
+              version: "0.0.7"
+        """
+
+        requirements2 = """
+        collections:
+            - name: "pulp.squeezer"
+              version: "0.0.17"
+        """
+
+        # sync the first version ...
         body = gen_ansible_remote(
             url="https://galaxy.ansible.com",
-            requirements_file="collections:\n  - pulp.squeezer",
+            requirements_file=requirements1,
             sync_dependencies=False,
         )
         remote = self.remote_collection_api.create(body)
@@ -51,20 +69,31 @@ class CollectionsV3TestCase(TestCaseUsingBindings, SyncHelpersMixin):
             "squeezer", "pulp", distribution.base_path
         ).meta.count
 
-        data = {"remove_content_units": [versions.results[0].pulp_href]}
-        response = self.repo_api.modify(repo.pulp_href, data)
-        monitor_task(response.task)
+        # sync the second version ...
+        body = gen_ansible_remote(
+            url="https://galaxy.ansible.com",
+            requirements_file=requirements2,
+            sync_dependencies=False,
+        )
+        self.remote_collection_api.update(remote.pulp_href, body)
+        repository_sync_data = AnsibleRepositorySyncURL(remote=remote.pulp_href, optimize=True)
+        sync_response = self.repo_api.sync(repo.pulp_href, repository_sync_data)
+        monitor_task(sync_response.task)
+        task = tasks.read(sync_response.task)
+        self.assertEqual(task.state, "completed")
 
+        # enumerate new data after 2nd sync ...
         collections = self.collections_api.list(distribution.base_path)
         highest_version = collections.data[0].highest_version["version"]
         updated_at = collections.data[0].updated_at
-
         total_versions = self.collections_versions_v3api.list(
             "squeezer", "pulp", distribution.base_path
         ).meta.count
 
-        self.assertEqual(highest_version, original_highest_version)
-        self.assertEqual(original_total_versions, total_versions + 1)
+        self.assertEqual(original_highest_version, "0.0.7")
+        self.assertEqual(highest_version, "0.0.17")
+        self.assertEqual(original_total_versions, 1)
+        self.assertEqual(total_versions, 2)
         self.assertGreater(updated_at, original_updated_at)
 
     def test_v3_collection_version_from_synced_data(self):


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-3154

The current code emits an updated_at date that reflects the timestamp of when the version was added to the repository, instead of when the newest version was last updated