### PR TITLE
Fix constraints violation on is_highest in import

### DIFF
--- a/CHANGES/1986.bugfix
+++ b/CHANGES/1986.bugfix
@@ -1,0 +1,1 @@
+Set `is_highest` to `False` before importing a collection version to prevent conflicts.

--- a/pulp_ansible/app/modelresource.py
+++ b/pulp_ansible/app/modelresource.py
@@ -115,6 +115,9 @@ class CollectionVersionContentResource(BaseContentResource):
 
         col = Collection.objects.get(name=row["name"], namespace=row["namespace"])
         row["collection"] = str(col.pk)
+        # This field easily produces constraints violations.
+        # But it's neither useful nor correct. It's removed in newer versions anyway.
+        row["is_highest"] = False
 
     def set_up_queryset(self):
         """


### PR DESCRIPTION
This field is not correct anyway and it is removed in newer versions. We only set it to False here hoping it will not be worse but also as the minimal possible change.

Fixes #1986