### PR TITLE
[PR #1995/2d90c0c5 backport][0.18] Fix Any serializer type regression breaking Ruby bindings

### DIFF
--- a/CHANGES/+fix-any-type.bugfix
+++ b/CHANGES/+fix-any-type.bugfix
@@ -1,0 +1,2 @@
+Fixed the JSONField specification so it doesn't break ruby bindings.
+See context [here](https://github.com/pulp/pulp_rpm/issues/3639).

--- a/pulp_ansible/app/fields.py
+++ b/pulp_ansible/app/fields.py
@@ -1,0 +1,12 @@
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
+from rest_framework import serializers
+
+
+@extend_schema_field(OpenApiTypes.OBJECT)
+class JSONDictField(serializers.JSONField):
+    """A drf JSONField override to force openapi schema to use 'object' type.
+
+    Not strictly correct, but we relied on that for a long time.
+    See: https://github.com/tfranzel/drf-spectacular/issues/1095
+    """

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -6,7 +6,7 @@ from drf_spectacular.types import OpenApiTypes
 from rest_framework.reverse import reverse
 from rest_framework import serializers, relations
 
-from pulp_ansible.app import models, serializers as ansible_serializers
+from pulp_ansible.app import models, fields, serializers as ansible_serializers
 from pulpcore.plugin.models import ContentArtifact, RepositoryVersion
 from pulpcore.plugin import serializers as core_serializers
 
@@ -312,10 +312,10 @@ class CollectionVersionSerializer(UnpaginatedCollectionVersionSerializer):
     A serializer for a CollectionVersion.
     """
 
-    manifest = serializers.JSONField(
+    manifest = fields.JSONDictField(
         help_text="A JSON field holding MANIFEST.json data.", read_only=True
     )
-    files = serializers.JSONField(help_text="A JSON field holding FILES.json data.", read_only=True)
+    files = fields.JSONDictField(help_text="A JSON field holding FILES.json data.", read_only=True)
 
     class Meta:
         model = models.CollectionVersion
@@ -328,7 +328,7 @@ class CollectionVersionSerializer(UnpaginatedCollectionVersionSerializer):
 class CollectionVersionDocsSerializer(serializers.ModelSerializer):
     """A serializer to display the docs_blob of a CollectionVersion."""
 
-    docs_blob = serializers.JSONField()
+    docs_blob = fields.JSONDictField()
 
     class Meta:
         fields = ("docs_blob",)

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -46,6 +46,7 @@ from .models import (
     Role,
     Tag,
 )
+from pulp_ansible.app import fields
 from pulp_ansible.app.schema import COPY_CONFIG_SCHEMA
 from pulp_ansible.app.tasks.utils import (
     parse_collections_requirements_file,
@@ -544,11 +545,11 @@ class CollectionVersionSerializer(ContentChecksumSerializer, CollectionVersionUp
         read_only=True,
     )
 
-    contents = serializers.JSONField(
+    contents = fields.JSONDictField(
         help_text=_("A JSON field with data about the contents."), read_only=True
     )
 
-    dependencies = serializers.JSONField(
+    dependencies = fields.JSONDictField(
         help_text=_(
             "A dict declaring Collections that this collection requires to be installed for it to "
             "be usable."
@@ -562,16 +563,16 @@ class CollectionVersionSerializer(ContentChecksumSerializer, CollectionVersionUp
         read_only=True,
     )
 
-    docs_blob = serializers.JSONField(
+    docs_blob = fields.JSONDictField(
         help_text=_("A JSON field holding the various documentation blobs in the collection."),
         read_only=True,
     )
 
-    manifest = serializers.JSONField(
+    manifest = fields.JSONDictField(
         help_text=_("A JSON field holding MANIFEST.json data."), read_only=True
     )
 
-    files = serializers.JSONField(
+    files = fields.JSONDictField(
         help_text=_("A JSON field holding FILES.json data."), read_only=True
     )
 
@@ -1000,8 +1001,8 @@ class CollectionImportDetailSerializer(CollectionImportListSerializer):
     A serializer for a CollectionImport detail view.
     """
 
-    error = serializers.JSONField(source="task.error", required=False)
-    messages = serializers.JSONField()
+    error = fields.JSONDictField(source="task.error", required=False)
+    messages = fields.JSONDictField()
 
     class Meta(CollectionImportListSerializer.Meta):
         fields = CollectionImportListSerializer.Meta.fields + ("error", "messages")
@@ -1046,7 +1047,7 @@ class CopySerializer(serializers.Serializer):
     A serializer for Content Copy API.
     """
 
-    config = serializers.JSONField(
+    config = fields.JSONDictField(
         help_text=_("A JSON document describing sources, destinations, and content to be copied"),
     )
 


### PR DESCRIPTION
See https://github.com/pulp/pulp_rpm/issues/3639

(cherry picked from commit 2d90c0c53c38b24db435d4654f9eef5c1d05c673)