### PR TITLE
Add stricter upperbound for galaxy-importer to account for dropping of py3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async_lru>=1.0,<2.1
-galaxy_importer>=0.4.5,<0.5
+galaxy_importer>=0.4.5,<0.4.27
 GitPython>=3.1.24,<3.2
 jsonschema>=4.9,<4.21
 Pillow>=7.0,<10.4


### PR DESCRIPTION
Our older images <core3.49 use python3.8. A recent release of galaxy-importer now uses code not present in py3.8, and it seems they haven't been testing 3.8 for a while. So restrict to last known supported version: https://github.com/ansible/galaxy-importer/commit/109c1ee9744be6c3c337a9efa065482dbd032172