### PR TITLE
Fix a regression in git sync introduced in pulpcore 3.73

### DIFF
--- a/CHANGES/+git-sync-bad-serialize.bugfix
+++ b/CHANGES/+git-sync-bad-serialize.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the git sync caused by a bad serialization after pulpcore 3.73.0.

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -726,6 +726,7 @@ class CollectionVersionSerializer(ContentChecksumSerializer, CollectionVersionUp
             "pulp_created",
             "pulp_last_updated",
             "sha256",
+            "pulp_labels",
         }
         model = CollectionVersion
 


### PR DESCRIPTION
Probably should rewrite the serializer read/write field check, but it's rare that we add a new field that is both read & write to Content serializers, so...