### PR TITLE
Work around an issue with drf 3.16

### DIFF
--- a/CHANGES/+search_list_serializer.bugfix
+++ b/CHANGES/+search_list_serializer.bugfix
@@ -1,0 +1,1 @@
+Added a workaround to the `CollectionVersionSearchListSerializer` to allow installing djangorestframework>=3.16.

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -393,6 +393,11 @@ class CollectionVersionSearchListSerializer(CollectionVersionListSerializer):
             "is_deprecated",
             "is_signed",
         )
+        # This is a read only serializer.
+        # But the uniqueness of the underlying model interfers with the SerilizerMethodField.
+        # See https://github.com/encode/django-rest-framework/pull/9531#issuecomment-2778892573 .
+        # This is a workaround. I don't even expect it to work forever.
+        validators = []
 
     def get_repository_version(self, obj) -> str:
         if obj.repository_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
   "pulpcore>=3.49.0,<3.85",
   "PyYAML>=5.4.1,<7.0",
   "semantic_version>=2.9,<2.11",
-  "djangorestframework<3.16",  # Pin to prevent an interference leading to bad openapi spec.
 ]
 
 [project.urls]


### PR DESCRIPTION
The CollectionVersionSearchListSerializer was missing the repository_version field for some interference with uniqueness constraints turning it into a hidden field.