### PR TITLE
Fix log for avatar downloads

### DIFF
--- a/CHANGES/+log_namespace.bugfix
+++ b/CHANGES/+log_namespace.bugfix
@@ -1,0 +1,1 @@
+Fixed namespace avatar download log.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -711,6 +711,7 @@ class CollectionSyncFirstStage(Stage):
                         remote=self.remote,
                         relative_path=f"{name}-avatar",
                         deferred_download=False,
+                        extra_data={"namespace": name},
                     )
                 ]
                 if url


### PR DESCRIPTION
https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/tasks/collections.py#L1070
```
2025-04-07 09:50:37,887 ERROR backoff: Giving up download_wrapper(...) after 1 tries (aiohttp.client_exceptions.ClientResponseError: 404, message='Not Found', url='https://www.hetzner.com/de/themes/hetzner/images/logo/hetzner-logo.svg')
2025-04-07 09:50:37,887 INFO pulp_ansible.app.tasks.collections: Failed to download namespace avatar: None - 404, message='Not Found', url='https://www.hetzner.com/de/themes/hetzner/images/logo/hetzner-logo.svg', Skipping
Giving up download_wrapper(...) after 1 tries (aiohttp.client_exceptions.ClientResponseError: 404, message='Not Found', url='https://www.hetzner.com/de/themes/hetzner/images/logo/hetzner-logo.svg')
```