### PR TITLE
Fix broken collection import logs

### DIFF
--- a/CHANGES/+import-logs.bugfix
+++ b/CHANGES/+import-logs.bugfix
@@ -1,0 +1,1 @@
+Fixed broken collection import logs.

--- a/pulp_ansible/app/settings.py
+++ b/pulp_ansible/app/settings.py
@@ -2,7 +2,7 @@ import socket
 
 LOGGING = {
     "loggers": {
-        "pulp_ansible.app.tasks.collection.import_collection": {
+        "pulp_ansible.app.tasks.upload.process_collection_artifact": {
             "level": "INFO",
             "handlers": ["collection_import"],
             "propagate": False,


### PR DESCRIPTION
Connected pulp_ansible.app.tasks.upload.process_collection_artifact logger to collection_import handler.

fixes: PULP-525