### PR TITLE
Add results to syncronize tasks

### DIFF
--- a/CHANGES/+sync_result.feature
+++ b/CHANGES/+sync_result.feature
@@ -1,0 +1,1 @@
+Added results to syncronize tasks.


### PR DESCRIPTION
If a new repository version is created, it is returned as the task result now.