### PR TITLE
Fix cross-repo search tag filter for ArrayField

### DIFF
--- a/pulp_ansible/app/galaxy/v3/filters.py
+++ b/pulp_ansible/app/galaxy/v3/filters.py
@@ -187,6 +187,4 @@ class CollectionVersionSearchFilter(FilterSet):
         Returns:
             Queryset of CollectionVersion that matches all tags
         """
-        for tag in value.split(","):
-            qs = qs.filter(collection_version__tags__name=tag)
-        return qs
+        return qs.filter(collection_version__tags__contains=value.split(","))


### PR DESCRIPTION
The tags field on CollectionVersion is now an ArrayField instead of a ForeignKey to Tag model. Updated filter_by_tags to use the contains lookup which is appropriate for ArrayFields.

Issue: AAP-53522

Fixes: #2350
