### PR TITLE
[PULP-968] Exclude excessive fields from cv view

### DIFF
--- a/CHANGES/+cv_list_oom.bugfix
+++ b/CHANGES/+cv_list_oom.bugfix
@@ -1,0 +1,1 @@
+Exclude some bloated fields by default from the collection version views.

--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -665,6 +665,22 @@ class CollectionVersionSerializer(ContentChecksumSerializer, CollectionVersionUp
 
     creating = True
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            request = self.context["request"]
+            if request.method != "GET":
+                return
+        except (AttributeError, TypeError, KeyError):
+            # The serializer was not initialized with request context.
+            return
+        query_params = request.query_params
+        if self.include_arg_name in query_params or self.exclude_arg_name in query_params:
+            return
+        for fieldname in ["files", "manifest", "docs_blob", "contents"]:
+            # Redact these fields by default as they have no size limit.
+            self.fields.pop(fieldname)
+
     def validate(self, data):
         """Run super() validate if creating, else return data."""
         # This validation is for creating CollectionVersions


### PR DESCRIPTION
The fields "files", "manifest", "docs_blob" and "contents" can contain so much data the the list view runs out of memory killing the api app. We now only show them when the user requests to do so.