### PR TITLE
AAP-57585: Exclude contents field from search endpoint to prevent OOM

### DIFF
--- a/CHANGES/AAP-57585.bugfix
+++ b/CHANGES/AAP-57585.bugfix
@@ -1,0 +1,1 @@
+Excluded contents field from collection version search endpoint to prevent OOM.

--- a/pulp_ansible/app/galaxy/v3/serializers.py
+++ b/pulp_ansible/app/galaxy/v3/serializers.py
@@ -357,7 +357,6 @@ class CollectionSummarySerializer(ansible_serializers.CollectionVersionSerialize
             "version",
             "requires_ansible",
             "pulp_created",
-            "contents",
             "dependencies",
             "description",
             "tags",


### PR DESCRIPTION
## Summary

Fixes worker timeout and OOM errors on `/api/galaxy/v3/plugin/ansible/search/collection-versions/` endpoint when requesting larger result sets (e.g., `limit=100`).

## Root Cause

The `CollectionSummarySerializer` (used by the search endpoint) includes the `contents` field - a JSON blob containing all modules, roles, plugins, etc. in each collection version. This can be megabytes of data per collection.

While commit b6cefc84 added a fix to exclude large fields from the regular `CollectionVersionSerializer`, this fix doesn't apply to the search endpoint because:

1. `CollectionSummarySerializer()` is instantiated as a class-level attribute at import time
2. At that moment, no request context exists
3. The parent's `__init__` checks for request context and returns early if missing
4. Result: `contents` is never excluded from the nested serializer

With `limit=100` and ~50KB average `contents` per collection version, the endpoint tries to serialize 5MB+ of JSON just for that field, causing memory exhaustion and worker kills.

## Fix

Remove `contents` from `CollectionSummarySerializer.Meta.fields`. Users can fetch full collection version details from the individual CV endpoint if needed.

## Test Plan

- [ ] Verify `limit=100` query no longer causes timeout/OOM
- [ ] Verify search results no longer include `contents` field
- [ ] Verify individual CV endpoint still returns `contents` when requested

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>