### PR TITLE
Mark distribution update/delete as non-immediate

### DIFF
--- a/CHANGES/2445.bugfix
+++ b/CHANGES/2445.bugfix
@@ -1,0 +1,1 @@
+Marked distribution update and delete operations as non-immediate due to heavy index rebuild hooks.

--- a/pulp_ansible/app/viewsets.py
+++ b/pulp_ansible/app/viewsets.py
@@ -1128,6 +1128,8 @@ class AnsibleDistributionViewSet(DistributionViewSet, RolesMixin):
     endpoint_name = "ansible"
     queryset = AnsibleDistribution.objects.all()
     serializer_class = AnsibleDistributionSerializer
+    ALLOW_NON_BLOCKING_UPDATE = False
+    ALLOW_NON_BLOCKING_DELETE = False
 
     queryset_filtering_required_permission = "ansible.view_ansibledistribution"
 


### PR DESCRIPTION
AnsibleDistribution lifecycle hooks trigger heavy index rebuilds, so update and delete should not be dispatched with `immediate=True`. Pulpcore exposes the control of whether this can be run immediately via `ALLOW_NON_BLOCKING_UPDATE` and `ALLOW_NON_BLOCKING_DELETE`.

Fixes #2445 

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
