### PR TITLE
Sync only latest version of collections by default

### DIFF
--- a/CHANGES/+collection_sync_latest.removal
+++ b/CHANGES/+collection_sync_latest.removal
@@ -1,0 +1,1 @@
+Optimize collection sync to only fetch the latest version when no requirements filter is provided.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -992,7 +992,23 @@ class CollectionSyncFirstStage(Stage):
 
     async def _find_all_collections(self):
         if self._unpaginated_collection_version_metadata:
-            await self._find_all_collections_from_unpaginated_data()
+            loop = asyncio.get_event_loop()
+            tasks = []
+            for namespace, collections in self._unpaginated_collection_metadata.items():
+                for name, collection in collections.items():
+                    highest = (collection.get("highest_version") or {}).get("version")
+                    version_spec = f"=={highest}" if highest else "*"
+                    entry = RequirementsFileEntry(
+                        name=f"{namespace}.{name}",
+                        version=version_spec,
+                        source=None,
+                    )
+                    tasks.append(
+                        loop.create_task(self._fetch_collection_metadata(entry))
+                    )
+            self.parsing_metadata_progress_bar.total = len(tasks)
+            await self.parsing_metadata_progress_bar.asave(update_fields=["total"])
+            await asyncio.gather(*tasks)
             return
 
         collection_endpoint, api_version = await self._get_paginated_collection_api(self.remote.url)
@@ -1014,12 +1030,18 @@ class CollectionSyncFirstStage(Stage):
             for collection in collections:
                 if api_version == 2:
                     namespace = collection["namespace"]["name"]
+                    latest_version = (
+                        collection.get("latest_version") or {}
+                    ).get("version")
                 else:
                     namespace = collection["namespace"]
+                    latest_version = (
+                        collection.get("highest_version") or {}
+                    ).get("version")
                 name = collection["name"]
                 requirements_file = RequirementsFileEntry(
                     name=".".join([namespace, name]),
-                    version="*",
+                    version=f"=={latest_version}" if latest_version else "*",
                     source=None,
                 )
                 tasks.append(loop.create_task(self._fetch_collection_metadata(requirements_file)))


### PR DESCRIPTION
The behavior of the current collection sync without a requirements file is to pull all collections and every version available of each collection.  This can lead to failures in the collection sync process due to memory inefficiencies in how collection syncs are performed. 

This PR switches the default behavior to only sync the latest version of each collection that is available.  
 
The current behavior can be achieved by providing a requirements file with a version set to a wildcard or version range.

Assisted By: Claude Code

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

