### PR TITLE
Reduce memory usage during collection deletion

### DIFF
--- a/CHANGES/+collection_delete_memory.bugfix
+++ b/CHANGES/+collection_delete_memory.bugfix
@@ -1,1 +1,1 @@
-Reduced memory usage when deleting collections with many versions.
+Reduced memory usage when deleting collections with many versions by using targeted QuerySet field selection with `.only()` to avoid loading unnecessary JSON fields.

--- a/CHANGES/+collection_delete_memory.bugfix
+++ b/CHANGES/+collection_delete_memory.bugfix
@@ -1,0 +1,1 @@
+Reduced memory usage when deleting collections with many versions.

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -80,7 +80,7 @@ from pulp_ansible.app.viewsets import (
 
 from pulp_ansible.app.tasks.deletion import delete_collection_version, delete_collection
 
-from pulp_ansible.app.utils import filter_content_for_repo_version, set_collection_deferred_fields
+from pulp_ansible.app.utils import filter_content_for_repo_version
 
 DOMAIN_ENABLED = settings.DOMAIN_ENABLED
 
@@ -446,15 +446,9 @@ class CollectionViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Defer loading large JSON fields to prevent memory exhaustion
-        set_collection_deferred_fields(
-            ["contents", "docs_blob", "manifest", "files", "dependencies"]
-        )
-
         repositories = set()
-        for version in collection.versions.all():
-            for repo in version.repositories.all():
-                repositories.add(repo)
+        for version in collection.versions.only("pk"):
+            repositories.update(version.repositories.only("pk"))
 
         async_result = dispatch(
             delete_collection,
@@ -469,9 +463,9 @@ def get_collection_dependents(parent):
     """Given a parent collection, return a list of collection versions that depend on it."""
     key = f"{parent.namespace}.{parent.name}"
     return list(
-        CollectionVersion.objects.exclude(collection=parent).filter(
-            dependencies__has_key=key, pulp_domain=get_domain()
-        )
+        CollectionVersion.objects.exclude(collection=parent)
+        .filter(dependencies__has_key=key, pulp_domain=get_domain())
+        .only("namespace", "name", "version")
     )
 
 

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -80,7 +80,7 @@ from pulp_ansible.app.viewsets import (
 
 from pulp_ansible.app.tasks.deletion import delete_collection_version, delete_collection
 
-from pulp_ansible.app.utils import filter_content_for_repo_version
+from pulp_ansible.app.utils import filter_content_for_repo_version, set_collection_deferred_fields
 
 DOMAIN_ENABLED = settings.DOMAIN_ENABLED
 
@@ -445,6 +445,11 @@ class CollectionViewSet(
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+        # Defer loading large JSON fields to prevent memory exhaustion
+        set_collection_deferred_fields(
+            ["contents", "docs_blob", "manifest", "files", "dependencies"]
+        )
 
         repositories = set()
         for version in collection.versions.all():

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -57,6 +57,7 @@ from pulp_ansible.app.models import (
     AnsibleCollectionDeprecated,
     AnsibleDistribution,
     AnsibleNamespaceMetadata,
+    AnsibleRepository,
     Collection,
     CollectionDownloadCount,
     CollectionVersion,
@@ -449,6 +450,7 @@ class CollectionViewSet(
         repositories = set()
         for version in collection.versions.only("pk"):
             repositories.update(version.repositories.only("pk"))
+        repositories = AnsibleRepository.objects.filter(pk__in=repositories)
 
         async_result = dispatch(
             delete_collection,

--- a/pulp_ansible/app/tasks/deletion.py
+++ b/pulp_ansible/app/tasks/deletion.py
@@ -17,7 +17,6 @@ import logging
 from collections import defaultdict
 
 from pulp_ansible.app.models import Collection, CollectionVersion
-from pulp_ansible.app.utils import set_collection_deferred_fields
 from pulpcore.plugin.tasking import add_and_remove, orphan_cleanup
 
 log = logging.getLogger(__name__)
@@ -33,7 +32,7 @@ def _remove_collection_version_from_repos(collection_versions):
     """Remove CollectionVersions from latest RepositoryVersion of each repo."""
     repos_with_collections_to_delete = defaultdict(list)
     for collection_version in collection_versions:
-        for repo in collection_version.repositories.all():
+        for repo in collection_version.repositories.only("pk"):
             repos_with_collections_to_delete[repo].append(collection_version.pk)
     for repo, collections in repos_with_collections_to_delete.items():
         add_and_remove(repo.pk, add_content_units=[], remove_content_units=collections)
@@ -72,11 +71,8 @@ def delete_collection(collection_pk):
     2. Run orphan_cleanup to delete the CollectionVersions
     3. Delete Collection
     """
-    # Defer loading large JSON fields to prevent memory exhaustion
-    set_collection_deferred_fields(["contents", "docs_blob", "manifest", "files", "dependencies"])
-
     collection = Collection.objects.get(pk=collection_pk)
-    versions = collection.versions.all()
+    versions = collection.versions.only("pk")
     _remove_collection_version_from_repos(versions)
     version_pks = versions.values_list("pk", flat=True)
 

--- a/pulp_ansible/app/tasks/deletion.py
+++ b/pulp_ansible/app/tasks/deletion.py
@@ -17,6 +17,7 @@ import logging
 from collections import defaultdict
 
 from pulp_ansible.app.models import Collection, CollectionVersion
+from pulp_ansible.app.utils import set_collection_deferred_fields
 from pulpcore.plugin.tasking import add_and_remove, orphan_cleanup
 
 log = logging.getLogger(__name__)
@@ -71,6 +72,9 @@ def delete_collection(collection_pk):
     2. Run orphan_cleanup to delete the CollectionVersions
     3. Delete Collection
     """
+    # Defer loading large JSON fields to prevent memory exhaustion
+    set_collection_deferred_fields(["contents", "docs_blob", "manifest", "files", "dependencies"])
+
     collection = Collection.objects.get(pk=collection_pk)
     versions = collection.versions.all()
     _remove_collection_version_from_repos(versions)


### PR DESCRIPTION
## Reduce memory usage during collection deletion

### Problem
Deleting collections with many versions causes worker processes to consume excessive memory and get killed with SIGKILL. This occurs because Django loads all fields (including large JSON fields) for each CollectionVersion into memory. When multiplied across many versions, this causes the worker process to be terminated.

### Solution
This PR applies targeted QuerySet field selection using `.only()` to load only the fields needed for deletion operations, avoiding the large JSON fields that aren't required.

**Changes:**
- `pulp_ansible/app/galaxy/v3/views.py`: 
  - Use `.only("pk")` when iterating collection versions and their repositories in `CollectionViewSet.destroy()`
  - Batch `AnsibleRepository` lookup with `filter(pk__in=...)` to prevent N+1 queries
  - Use `.only("namespace", "name", "version")` when loading collection dependents
- `pulp_ansible/app/tasks/deletion.py`: 
  - Use `.only("pk")` when loading collection versions and iterating their repositories in `delete_collection()` task

By loading only the required fields, we avoid pulling large JSON blobs (`docs_blob`, `metadata`, `dependencies`, etc.) into memory when they're not needed for the deletion operation.

### Related Work
- #2454 - Applied similar memory optimizations to collection sync operations
