### PR TITLE
Backport #2492: Reduce memory usage during collection deletion

### DIFF
--- a/CHANGES/+collection_delete_memory.bugfix
+++ b/CHANGES/+collection_delete_memory.bugfix
@@ -1,0 +1,1 @@
+Reduced memory usage when deleting collections with many versions by using targeted QuerySet field selection with `.only()` to avoid loading unnecessary JSON fields.

--- a/pulp_ansible/app/galaxy/v3/views.py
+++ b/pulp_ansible/app/galaxy/v3/views.py
@@ -57,6 +57,7 @@ from pulp_ansible.app.models import (
     AnsibleCollectionDeprecated,
     AnsibleDistribution,
     AnsibleNamespaceMetadata,
+    AnsibleRepository,
     Collection,
     CollectionDownloadCount,
     CollectionVersion,
@@ -462,9 +463,9 @@ class CollectionViewSet(
             )
 
         repositories = set()
-        for version in collection.versions.all():
-            for repo in version.repositories.all():
-                repositories.add(repo)
+        for version in collection.versions.only("pk"):
+            repositories.update(version.repositories.only("pk"))
+        repositories = AnsibleRepository.objects.filter(pk__in=repositories)
 
         async_result = dispatch(
             delete_collection,
@@ -479,7 +480,9 @@ def get_collection_dependents(parent):
     """Given a parent collection, return a list of collection versions that depend on it."""
     key = f"{parent.namespace}.{parent.name}"
     return list(
-        CollectionVersion.objects.exclude(collection=parent).filter(dependencies__has_key=key)
+        CollectionVersion.objects.exclude(collection=parent)
+        .filter(dependencies__has_key=key)
+        .only("namespace", "name", "version")
     )
 
 

--- a/pulp_ansible/app/tasks/deletion.py
+++ b/pulp_ansible/app/tasks/deletion.py
@@ -32,7 +32,7 @@ def _remove_collection_version_from_repos(collection_versions):
     """Remove CollectionVersions from latest RepositoryVersion of each repo."""
     repos_with_collections_to_delete = defaultdict(list)
     for collection_version in collection_versions:
-        for repo in collection_version.repositories.all():
+        for repo in collection_version.repositories.only("pk"):
             repos_with_collections_to_delete[repo].append(collection_version.pk)
     for repo, collections in repos_with_collections_to_delete.items():
         add_and_remove(repo.pk, add_content_units=[], remove_content_units=collections)
@@ -72,7 +72,7 @@ def delete_collection(collection_pk):
     3. Delete Collection
     """
     collection = Collection.objects.get(pk=collection_pk)
-    versions = collection.versions.all()
+    versions = collection.versions.only("pk")
     _remove_collection_version_from_repos(versions)
     version_pks = versions.values_list("pk", flat=True)
 


### PR DESCRIPTION
Backport of #2492 to the 0.21 branch.

Uses `.only()` on QuerySets to avoid loading large JSON fields during collection deletion, reducing memory usage for collections with many versions.

**Changes:**
- `views.py`: Use `.only("pk")` for version/repo iteration, batch `AnsibleRepository` lookup, add `.only("namespace", "name", "version")` to `get_collection_dependents`
- `deletion.py`: Use `.only("pk")` for version/repo iteration

Made with [Cursor](https://cursor.com)