### PR TITLE
Adopt the "ArtifactResourceBudget" limiter from Pulpcore

### DIFF
--- a/CHANGES/+resource-budget.feature
+++ b/CHANGES/+resource-budget.feature
@@ -1,0 +1,1 @@
+Take advantage of pulpcore's `ResourceBudget` feature which enables the sync pipeline to keep disk usage down without an excessive performance hit.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -41,6 +41,7 @@ from pulpcore.plugin.models import (
 )
 from pulpcore.plugin.stages import (
     ArtifactDownloader,
+    ArtifactResourceBudget,
     ArtifactSaver,
     ContentAssociation,
     ContentSaver,
@@ -213,7 +214,7 @@ async def declarative_content_from_git_repo(remote, url, git_ref=None, metadata_
     return d_content
 
 
-def sync(remote_pk, repository_pk, mirror, optimize):
+def sync(remote_pk, repository_pk, mirror, optimize, **kwargs):
     """
     Sync Collections with ``remote_pk``, and save a new RepositoryVersion for ``repository_pk``.
 
@@ -479,11 +480,12 @@ class AnsibleDeclarativeVersion(DeclarativeVersion):
             list: List of :class:`~pulpcore.plugin.stages.Stage` instances
 
         """
+        resource_budget = ArtifactResourceBudget.from_settings()
         pipeline = [
             self.first_stage,
             QueryExistingArtifacts(),
-            ArtifactDownloader(),
-            ArtifactSaver(),
+            ArtifactDownloader(resource_budget=resource_budget),
+            ArtifactSaver(resource_budget=resource_budget),
             QueryExistingContents(),
             DocsBlobDownloader(),
             AnsibleContentSaver(new_version),

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -40,6 +40,7 @@ from pulpcore.plugin.models import (
 )
 from pulpcore.plugin.stages import (
     ArtifactDownloader,
+    ArtifactResourceBudget,
     ArtifactSaver,
     ContentAssociation,
     ContentSaver,
@@ -213,7 +214,7 @@ async def declarative_content_from_git_repo(remote, url, git_ref=None, metadata_
     return d_content
 
 
-def sync(remote_pk, repository_pk, mirror, optimize):
+def sync(remote_pk, repository_pk, mirror, optimize, **kwargs):
     """
     Sync Collections with ``remote_pk``, and save a new RepositoryVersion for ``repository_pk``.
 
@@ -479,11 +480,12 @@ class AnsibleDeclarativeVersion(DeclarativeVersion):
             list: List of :class:`~pulpcore.plugin.stages.Stage` instances
 
         """
+        resource_budget = ArtifactResourceBudget.from_settings()
         pipeline = [
             self.first_stage,
             QueryExistingArtifacts(),
-            ArtifactDownloader(),
-            ArtifactSaver(),
+            ArtifactDownloader(resource_budget=resource_budget),
+            ArtifactSaver(resource_budget=resource_budget),
             QueryExistingContents(),
             DocsBlobDownloader(),
             AnsibleContentSaver(new_version),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "GitPython>=3.1.24,<3.2",
   "jsonschema>=4.9,<4.27",
   "Pillow>=10.3,<13",  # Semantic Versioning https://pillow.readthedocs.io/en/stable/releasenotes/versioning.html
-  "pulpcore>=3.105.0,<3.115",
+  "pulpcore>=3.111.0,<3.115",
   "PyYAML>=6.0.2,<7.0",
   "semantic_version>=2.9,<2.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "GitPython>=3.1.24,<3.2",
   "jsonschema>=4.9,<4.27",
   "Pillow>=10.3,<13",  # Semantic Versioning https://pillow.readthedocs.io/en/stable/releasenotes/versioning.html
-  "pulpcore>=3.105.13,<3.130",
+  "pulpcore>=3.115.0,<3.130",
   "PyYAML>=6.0.2,<7.0",
   "semantic_version>=2.9,<2.11",
 ]


### PR DESCRIPTION
Puts a limiter on the amount of data that can be held locally between artifact download and saving (to content storage).

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
