### PR TITLE
Bring back serializer ValidationError. Remove unused PulpExceptions.

### DIFF
--- a/pulp_ansible/app/serializers.py
+++ b/pulp_ansible/app/serializers.py
@@ -38,10 +38,6 @@ from pulp_ansible.app.tasks.utils import (
     parse_collection_filename,
     parse_collections_requirements_file,
 )
-from pulp_ansible.exceptions import (
-    CollectionFilenameParseError,
-    MissingExpectedFieldsError,
-)
 
 from .models import (
     AnsibleCollectionDeprecated,
@@ -484,12 +480,21 @@ class CollectionVersionUploadSerializer(SingleArtifactContentUploadSerializer):
         fields = ("namespace", "name", "version")
         if not all((f"expected_{x}" in data for x in fields)):
             if not ("file" in data or "filename" in self.context):
-                raise MissingExpectedFieldsError()
+                raise serializers.ValidationError(
+                    _(
+                        "expected_namespace, expected_name, and expected_version must be "
+                        "specified when using artifact or upload objects"
+                    )
+                )
             filename = self.context.get("filename") or data["file"].name
             try:
                 collection = parse_collection_filename(filename)
             except ValueError:
-                raise CollectionFilenameParseError(filename)
+                raise serializers.ValidationError(
+                    _("Failed to parse Collection file upload '{filename}'").format(
+                        filename=filename
+                    )
+                )
             data["expected_namespace"] = collection.namespace
             data["expected_name"] = collection.name
             data["expected_version"] = collection.version

--- a/pulp_ansible/app/tasks/utils.py
+++ b/pulp_ansible/app/tasks/utils.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import yaml
 from galaxy_importer.schema import MAX_LENGTH_NAME, MAX_LENGTH_VERSION
+from rest_framework.serializers import ValidationError
 from yaml.error import YAMLError
 
 from pulp_ansible.app.constants import PAGE_SIZE
@@ -14,12 +15,8 @@ from pulp_ansible.exceptions import (
     APIVersionNotFoundError,
     CollectionFieldTooLongError,
     CollectionFileNotFoundError,
-    CollectionNameRequiredError,
     InvalidCollectionFilenameError,
-    InvalidCollectionNameFormatError,
     InvalidCollectionVersionError,
-    InvalidRequirementsFormatError,
-    RequirementsFileParseError,
 )
 
 log = logging.getLogger(__name__)
@@ -138,12 +135,16 @@ def parse_collections_requirements_file(requirements_file_string):
             try:
                 requirements = yaml.safe_load(requirements_file_string)
             except YAMLError as err:
-                raise RequirementsFileParseError(requirements_file_string, str(err))
+                raise ValidationError(
+                    _(
+                        "Failed to parse the collection requirements yml: {file} with error {error}"
+                    ).format(file=requirements_file_string, error=str(err))
+                )
         else:
             requirements = requirements_file_string
 
         if not isinstance(requirements, dict) or "collections" not in requirements:
-            raise InvalidRequirementsFormatError(
+            raise ValidationError(
                 _(
                     "Expecting collections requirements file to be a dict with the key "
                     "collections that contains a list of collections to install."
@@ -151,7 +152,7 @@ def parse_collections_requirements_file(requirements_file_string):
             )
 
         if not isinstance(requirements["collections"], list):
-            raise InvalidRequirementsFormatError(
+            raise ValidationError(
                 _(
                     "Expecting collections requirements file to be a dict with the key "
                     "collections that contains a list of collections to install."
@@ -162,7 +163,9 @@ def parse_collections_requirements_file(requirements_file_string):
             if isinstance(collection_req, dict):
                 req_name = collection_req.get("name", None)
                 if req_name is None:
-                    raise CollectionNameRequiredError()
+                    raise ValidationError(
+                        _("Collections requirement entry should contain the key name.")
+                    )
 
                 req_version = collection_req.get("version", "*")
                 req_source = collection_req.get("source", None)
@@ -171,7 +174,12 @@ def parse_collections_requirements_file(requirements_file_string):
             else:
                 entry = RequirementsFileEntry(name=collection_req, version="*", source=None)
             if "." not in entry.name:
-                raise InvalidCollectionNameFormatError()
+                raise ValidationError(
+                    _(
+                        "Collections requirement entry should contain the collection name "
+                        "in the format <namespace>.<name>."
+                    )
+                )
             collection_info.append(entry)
 
     return collection_info

--- a/pulp_ansible/exceptions.py
+++ b/pulp_ansible/exceptions.py
@@ -18,27 +18,6 @@ class CollectionNotFound(PulpException):
         ).format(namespace=self.namespace, name=self.name, url=self.url)
 
 
-class CollectionFilenameParseError(PulpException):
-    """
-    Raised when unable to parse a collection filename.
-    """
-
-    error_code = "ANS0003"
-
-    def __init__(self, filename):
-        super().__init__()
-        """
-        :param filename: The filename that failed to parse
-        :type filename: str
-        """
-        self.filename = filename
-
-    def __str__(self):
-        return f"[{self.error_code}] " + _(
-            "Failed to parse Collection file upload '{filename}'"
-        ).format(filename=self.filename)
-
-
 class InvalidCollectionFilenameError(PulpException):
     """
     Raised when collection filename format is invalid.
@@ -168,90 +147,6 @@ class UnsupportedAPIVersionError(PulpException):
 
     def __str__(self):
         return f"[{self.error_code}] " + _("Unsupported API versions at {url}").format(url=self.url)
-
-
-class RequirementsFileParseError(PulpException):
-    """
-    Raised when unable to parse requirements file YAML.
-    """
-
-    error_code = "ANS0010"
-
-    def __init__(self, filename, error):
-        super().__init__()
-        """
-        :param filename: The requirements filename
-        :type filename: str
-        :param error: The parsing error details
-        :type error: str
-        """
-        self.filename = filename
-        self.error = error
-
-    def __str__(self):
-        return f"[{self.error_code}] " + _(
-            "Failed to parse the collection requirements yml: {file} with error {error}"
-        ).format(file=self.filename, error=self.error)
-
-
-class InvalidRequirementsFormatError(PulpException):
-    """
-    Raised when requirements file has invalid format or structure.
-    """
-
-    error_code = "ANS0011"
-
-    def __init__(self, message):
-        super().__init__()
-        """
-        :param message: Description of the format error
-        :type message: str
-        """
-        self.message = message
-
-    def __str__(self):
-        return f"[{self.error_code}] " + self.message
-
-
-class CollectionNameRequiredError(PulpException):
-    """
-    Raised when collection name is missing from requirements entry.
-    """
-
-    error_code = "ANS0012"
-
-    def __str__(self):
-        return f"[{self.error_code}] " + _(
-            "Collections requirement entry should contain the key name."
-        )
-
-
-class InvalidCollectionNameFormatError(PulpException):
-    """
-    Raised when collection name doesn't follow namespace.name format.
-    """
-
-    error_code = "ANS0013"
-
-    def __str__(self):
-        return f"[{self.error_code}] " + _(
-            "Collections requirement entry should contain the collection name in the "
-            "format <namespace>.<name>."
-        )
-
-
-class MissingExpectedFieldsError(PulpException):
-    """
-    Raised when expected_namespace, expected_name, expected_version are missing.
-    """
-
-    error_code = "ANS0014"
-
-    def __str__(self):
-        return f"[{self.error_code}] " + _(
-            "expected_namespace, expected_name, and expected_version must be "
-            "specified when using artifact or upload objects"
-        )
 
 
 class SignatureVerificationError(PulpException):


### PR DESCRIPTION
  Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
