### PR TITLE
Append `pk` to CV ordering filters for deterministic ordering

### DIFF
--- a/pulp_ansible/app/galaxy/v3/filters.py
+++ b/pulp_ansible/app/galaxy/v3/filters.py
@@ -10,13 +10,14 @@ from django_filters import (
 )
 from rest_framework.exceptions import ValidationError
 
+from pulpcore.filters import StableOrderingFilter
 from pulpcore.plugin.models import RepositoryVersion
 from pulpcore.plugin.viewsets import LabelFilter
 
 from pulp_ansible.app import models
 
 
-class SemanticVersionOrderingFilter(filters.OrderingFilter):
+class SemanticVersionOrderingFilter(StableOrderingFilter):
     def filter(self, qs, value):
         if value is not None and any(v in ["version", "-version"] for v in value):
             order = "-" if "-version" in value else ""

--- a/pulp_ansible/app/galaxy/v3/filters.py
+++ b/pulp_ansible/app/galaxy/v3/filters.py
@@ -10,9 +10,8 @@ from django_filters import (
 )
 from rest_framework.exceptions import ValidationError
 
-from pulpcore.filters import StableOrderingFilter
 from pulpcore.plugin.models import RepositoryVersion
-from pulpcore.plugin.viewsets import LabelFilter
+from pulpcore.plugin.viewsets import LabelFilter, StableOrderingFilter
 
 from pulp_ansible.app import models
 

--- a/pulp_ansible/tests/unit/test_ordering_filter.py
+++ b/pulp_ansible/tests/unit/test_ordering_filter.py
@@ -152,9 +152,11 @@ class TestCollectionVersionSearchFilterOrdering(TestCase):
             ]
         )
 
-        qs = self._apply_filter(qs, {"order_by": "version"})
-        first_run = list(qs.values_list("pk", flat=True))
-        second_run = list(qs.values_list("pk", flat=True))
+        qs1 = self._apply_filter(qs, {"order_by": "version"})
+        qs2 = self._apply_filter(qs, {"order_by": "version"})
+
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
 
         assert first_run == second_run
 
@@ -169,9 +171,10 @@ class TestCollectionVersionSearchFilterOrdering(TestCase):
             ]
         )
 
-        qs = self._apply_filter(qs, {})
-        first_run = list(qs.values_list("pk", flat=True))
-        second_run = list(qs.values_list("pk", flat=True))
+        qs1 = self._apply_filter(qs, {})
+        qs2 = self._apply_filter(qs, {})
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
 
         assert first_run == second_run
 
@@ -186,9 +189,10 @@ class TestCollectionVersionSearchFilterOrdering(TestCase):
             ]
         )
 
-        qs = self._apply_filter(qs, {"order_by": "name"})
-        first_run = list(qs.values_list("pk", flat=True))
-        second_run = list(qs.values_list("pk", flat=True))
+        qs1 = self._apply_filter(qs, {"order_by": "name"})
+        qs2 = self._apply_filter(qs, {"order_by": "name"})
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
 
         assert first_run == second_run
 

--- a/pulp_ansible/tests/unit/test_ordering_filter.py
+++ b/pulp_ansible/tests/unit/test_ordering_filter.py
@@ -1,0 +1,226 @@
+from django.test import RequestFactory, TestCase
+
+from pulp_ansible.app.galaxy.v3.filters import CollectionVersionSearchFilter
+from pulp_ansible.app.models import AnsibleRepository, Collection, CollectionVersion
+from pulp_ansible.app.models import CrossRepositoryCollectionVersionIndex as CVIndex
+
+from .utils import randstr
+
+
+class TestCollectionVersionSearchFilterOrdering(TestCase):
+    """Verify that CollectionVersionSearchFilter produces deterministic ordering."""
+
+    def _apply_filter(self, qs, params):
+        """Run CollectionVersionSearchFilter against a queryset with the given query params."""
+        request = RequestFactory().get("/", params)
+        request.query_params = request.GET
+        filterset = CollectionVersionSearchFilter(
+            data=request.query_params,
+            queryset=qs,
+            request=request,
+        )
+        return filterset.qs
+
+    def _build_index(self, specs):
+        """Create CVIndex rows from a list of (namespace, name, version) specs."""
+        repo = AnsibleRepository.objects.create(name=randstr())
+        for namespace, name, version in specs:
+            col, _ = Collection.objects.get_or_create(name=name)
+            cv = CollectionVersion.objects.create(
+                collection=col,
+                sha256=randstr(),
+                namespace=namespace,
+                name=name,
+                version=version,
+            )
+            CVIndex.objects.create(
+                repository=repo,
+                collection_version=cv,
+                is_deprecated=False,
+                is_signed=False,
+                is_highest=False,
+            )
+        return CVIndex.objects.all()
+
+    def test_order_by_name_ties_sorted_by_pk(self):
+        """Ensure rows with the same name are sub-sorted by pk descending."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "samename", "1.0.0"),
+                (ns, "samename", "2.0.0"),
+                (ns, "samename", "3.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "name"})
+        pks = list(qs.values_list("pk", flat=True))
+
+        # StableOrderingFilter appends -pk (descending) as tiebreaker
+        assert pks == sorted(pks, reverse=True)
+
+    def test_order_by_name_groups_correctly(self):
+        """Ensure ordering by name groups results alphabetically."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "charlie", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (ns, "bravo", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["alpha", "bravo", "charlie"]
+
+    def test_order_by_name_desc_groups_correctly(self):
+        """Ensure ordering by -name groups results in reverse alphabetical order."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "charlie", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (ns, "bravo", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "-name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["charlie", "bravo", "alpha"]
+
+    def test_order_by_namespace_ties_sorted_by_pk(self):
+        """Ensure rows with the same namespace are sub-sorted by pk descending."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "foo", "1.0.0"),
+                (ns, "bar", "1.0.0"),
+                (ns, "baz", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "namespace"})
+        pks = list(qs.values_list("pk", flat=True))
+
+        # StableOrderingFilter appends -pk (descending) as tiebreaker
+        assert pks == sorted(pks, reverse=True)
+
+    def test_order_by_version_semantic_ordering(self):
+        """Ensure version ordering uses the semver collation correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "col", "2.0.0"),
+                (ns, "col", "1.10.0"),
+                (ns, "col", "1.2.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        # semver collation sorts numerically, not lexicographically
+        assert versions == ["1.2.0", "1.10.0", "2.0.0"]
+
+    def test_order_by_version_desc_semantic_ordering(self):
+        """Ensure descending version ordering uses the semver collation correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "col", "2.0.0"),
+                (ns, "col", "1.10.0"),
+                (ns, "col", "1.2.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "-version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        assert versions == ["2.0.0", "1.10.0", "1.2.0"]
+
+    def test_order_by_version_ties_are_stable(self):
+        """Ensure rows with the same version produce stable ordering."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "aaa", "1.0.0"),
+                (ns, "bbb", "1.0.0"),
+                (ns, "ccc", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "version"})
+        first_run = list(qs.values_list("pk", flat=True))
+        second_run = list(qs.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_no_order_by_still_has_stable_ordering(self):
+        """Ensure a default stable ordering is applied even without order_by."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "foo", "1.0.0"),
+                (ns, "bar", "1.0.0"),
+                (ns, "baz", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {})
+        first_run = list(qs.values_list("pk", flat=True))
+        second_run = list(qs.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_order_by_name_returns_stable_results(self):
+        """Ensure results ordered by name are stable across repeated evaluations."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "samename", "1.0.0"),
+                (ns, "samename", "2.0.0"),
+                (ns, "samename", "3.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "name"})
+        first_run = list(qs.values_list("pk", flat=True))
+        second_run = list(qs.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_filter_by_name_with_ordering(self):
+        """Ensure filtering by name combined with ordering works correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "target", "1.0.0"),
+                (ns, "target", "2.0.0"),
+                (ns, "other", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"name": "target", "order_by": "version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        assert versions == ["1.0.0", "2.0.0"]
+
+    def test_filter_by_namespace_with_ordering(self):
+        """Ensure filtering by namespace combined with ordering works correctly."""
+        ns = randstr()
+        other_ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "bravo", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (other_ns, "charlie", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"namespace": ns, "order_by": "name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["alpha", "bravo"]


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AAP-75413

### Description
When using `order_by` with non-unique fields (e.g., name, namespace), the cross-repo search API can return results in inconsistent order across paginated requests. This causes items to change order on a same result.

This is reproducible in `https://console.redhat.com/api/automation-hub/v3/plugin/ansible/search/collection-versions/?repository_name=staging&order_by=namespace` (only when adding `order_by=namespace`). I suspect this is because many collection versions that share same namespace. Because I'm not able to reproduce locally with small dataset

### How it works
The fix appends pk as a tiebreaker to every explicit ORDER BY. For example, ?order_by=name previously generated:
`ORDER BY collection_version.name`
Now generates:
`ORDER BY collection_version.name, pk`

 This ensures that rows sharing the same name are always returned in a consistent, deterministic order based on their primary key.

### Changes
  - Add pk to `SemanticVersionOrderingFilter` for all ordering requests (name, namespace, pulp_created, version)
  - pk is only added when an explicit ordering is requested — unordered queries are not affected  
  - Also claude suggested to add pk after `-rank` in `filter_by_q` for deterministic full-text search results when multiple documents share the same relevance score
  - Add unit tests for `CollectionVersionSearchFilter` ordering behavior


 ### Workaround (prior)
 One of the workaround is to add &order_by=pulp_created as a secondary sort field. This workaround remains compatible with the fix.