### PR TITLE
feat(remotes/git): use username/password for authentication against git server

### DIFF
--- a/CHANGES/2565.feature
+++ b/CHANGES/2565.feature
@@ -1,0 +1,1 @@
+Support syncing from private repos using git remotes.

--- a/pulp_ansible/app/tasks/collections.py
+++ b/pulp_ansible/app/tasks/collections.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from collections.abc import Coroutine
 from gettext import gettext as _
 from pathlib import Path
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin, urlparse, urlunparse
 from uuid import uuid4
 
 import yaml
@@ -137,19 +137,52 @@ def _save_collection_version(collection_version, artifact):
         )
 
 
-async def declarative_content_from_git_repo(remote, url, git_ref=None, metadata_only=False):
+def _add_auth_to_git_url(url, remote):
+    if remote.password:
+        parsed = urlparse(url)
+        encoded_password = quote(remote.password, safe="")
+
+        if remote.username:
+            encoded_username = quote(remote.username, safe="")
+            new_netloc = f"{encoded_username}:{encoded_password}@{parsed.netloc}"
+        else:
+            new_netloc = f"token:{encoded_password}@{parsed.netloc}"
+
+        git_url = urlunparse(
+            (parsed.scheme, new_netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+        )
+    else:
+        git_url = url
+
+    return git_url
+
+
+async def declarative_content_from_git_repo(
+    remote, url, git_ref=None, metadata_only=False, authenticate_url=False
+):
     """Returns a DeclarativeContent for the Collection in a Git repository."""
+    if authenticate_url:
+        clone_url = _add_auth_to_git_url(url, remote)
+    else:
+        clone_url = url
+
     if git_ref:
         try:
             gitrepo = Repo.clone_from(
-                url, str(uuid4()), depth=1, branch=git_ref, multi_options=["--recurse-submodules"]
+                clone_url,
+                str(uuid4()),
+                depth=1,
+                branch=git_ref,
+                multi_options=["--recurse-submodules"],
             )
         except GitCommandError:
-            gitrepo = Repo.clone_from(url, str(uuid4()), multi_options=["--recurse-submodules"])
+            gitrepo = Repo.clone_from(
+                clone_url, str(uuid4()), multi_options=["--recurse-submodules"]
+            )
             gitrepo.git.checkout(git_ref)
     else:
         gitrepo = Repo.clone_from(
-            url, str(uuid4()), depth=1, multi_options=["--recurse-submodules"]
+            clone_url, str(uuid4()), depth=1, multi_options=["--recurse-submodules"]
         )
     commit_sha = gitrepo.head.commit.hexsha
     metadata, artifact_path = sync_collection(gitrepo.working_dir, ".")
@@ -802,7 +835,7 @@ class CollectionSyncFirstStage(Stage):
 
     async def _add_collection_version_from_git(self, url, gitref, metadata_only) -> list[Coroutine]:
         d_content = await declarative_content_from_git_repo(
-            self.remote, url, gitref, metadata_only=False
+            self.remote, url, gitref, metadata_only=False, authenticate_url=False
         )
         await self.put(d_content)
         return []

--- a/pulp_ansible/app/tasks/git.py
+++ b/pulp_ansible/app/tasks/git.py
@@ -107,7 +107,11 @@ class GitFirstStage(Stage):
             message="Cloning Git repository for Collection", code="sync.git.clone"
         ) as pb:
             d_content = await declarative_content_from_git_repo(
-                self.remote, self.remote.url, self.remote.git_ref, self.metadata_only
+                self.remote,
+                self.remote.url,
+                self.remote.git_ref,
+                self.metadata_only,
+                authenticate_url=True,
             )
             await self.put(d_content)
             await pb.aincrement()

--- a/pulp_ansible/tests/unit/test_tasks.py
+++ b/pulp_ansible/tests/unit/test_tasks.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from pulp_ansible.app.models import AnsibleDistribution, AnsibleRepository, CollectionVersion
 from pulp_ansible.app.tasks.collections import (
+    _add_auth_to_git_url,
     _rebuild_collection_version_meta,
     rebuild_repository_collection_versions_metadata,
 )
@@ -114,3 +115,43 @@ class TestCollectionReImport(TestCase):
         cv2 = cobject.cast()
         cv2.refresh_from_db()
         assert cv2.contents != ["a", "b", "c"]
+
+
+class TestAddAuthToGitUrl(TestCase):
+    """Test add_auth_to_git_url method."""
+
+    def test_add_auth_to_git_url_without_auth(self):
+        """Test that URL is unchanged when no password is provided."""
+        remote = mock.Mock()
+        remote.username = None
+        remote.password = None
+        url = "https://my-git-server.com/baz/my_public_repo.git"
+        final_url = _add_auth_to_git_url(url, remote)
+        assert final_url == url
+
+    def test_add_auth_to_git_url_with_username_and_password(self):
+        """Test adding username and password to a git URL."""
+        remote = mock.Mock()
+        remote.username = "foo"
+        remote.password = "bar"
+        url = "https://my-git-server.com/baz/my_private_repo.git"
+        final_url = _add_auth_to_git_url(url, remote)
+        assert final_url == "https://foo:bar@my-git-server.com/baz/my_private_repo.git"
+
+    def test_add_auth_to_git_url_with_password_only(self):
+        """Test adding password only (token) to a git URL."""
+        remote = mock.Mock()
+        remote.username = None
+        remote.password = "bar"
+        url = "https://my-git-server.com/baz/my_private_repo.git"
+        final_url = _add_auth_to_git_url(url, remote)
+        assert final_url == "https://token:bar@my-git-server.com/baz/my_private_repo.git"
+
+    def test_add_auth_to_git_url_with_special_characters(self):
+        """Test that special characters in username/password are URL-encoded."""
+        remote = mock.Mock()
+        remote.username = "foo:@"
+        remote.password = "bar:@"
+        url = "https://my-git-server.com/baz/my_private_repo.git"
+        final_url = _add_auth_to_git_url(url, remote)
+        assert final_url == "https://foo%3A%40:bar%3A%40@my-git-server.com/baz/my_private_repo.git"


### PR DESCRIPTION
closes #2565

### A note on attribution

These initial code changes were written by my colleague @Thorben-D, but I have been tasked with shepherding this PR to completion and merge. I have tested that the initial implementation works against the workflow described in the accompanying ticket, and I have added a changelog.

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added