### PR TITLE
[PR #2555/0043923 backport][0.25] Append `pk` to CV ordering filters for deterministic ordering

### DIFF
--- a/CHANGES/2555.bugfix
+++ b/CHANGES/2555.bugfix
@@ -1,0 +1,1 @@
+Append pk to collection version ordering filters for deterministic cross-repo search pagination.

--- a/pulp_ansible/app/galaxy/v3/filters.py
+++ b/pulp_ansible/app/galaxy/v3/filters.py
@@ -1,5 +1,6 @@
 import semantic_version
 from django.contrib.postgres.search import SearchQuery
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import Case, Q, Value, When
 from django.db.models import fields as db_fields
 from django.db.models.expressions import F, Func
@@ -13,10 +14,30 @@ from rest_framework.exceptions import ValidationError
 from pulpcore.plugin.models import RepositoryVersion
 from pulpcore.plugin.viewsets import LabelFilter
 
+try:
+    from pulpcore.plugin.viewsets import StableOrderingFilter
+except ImportError:
+
+    class StableOrderingFilter(filters.OrderingFilter):
+        """
+        Ordering filter with a stabilized order by either creation date, if available or primary key.
+        """
+
+        def filter(self, qs, value):
+            try:
+                field = qs.model._meta.get_field("pulp_created")
+            except FieldDoesNotExist:
+                field = qs.model._meta.pk
+
+            ordering = [self.get_ordering_value(param) for param in value or []]
+            ordering.append("-" + field.name)
+            return qs.order_by(*ordering)
+
+
 from pulp_ansible.app import models
 
 
-class SemanticVersionOrderingFilter(filters.OrderingFilter):
+class SemanticVersionOrderingFilter(StableOrderingFilter):
     def filter(self, qs, value):
         if value is not None and any(v in ["version", "-version"] for v in value):
             order = "-" if "-version" in value else ""

--- a/pulp_ansible/tests/unit/test_ordering_filter.py
+++ b/pulp_ansible/tests/unit/test_ordering_filter.py
@@ -1,0 +1,230 @@
+from django.test import RequestFactory, TestCase
+
+from pulp_ansible.app.galaxy.v3.filters import CollectionVersionSearchFilter
+from pulp_ansible.app.models import AnsibleRepository, Collection, CollectionVersion
+from pulp_ansible.app.models import CrossRepositoryCollectionVersionIndex as CVIndex
+
+from .utils import randstr
+
+
+class TestCollectionVersionSearchFilterOrdering(TestCase):
+    """Verify that CollectionVersionSearchFilter produces deterministic ordering."""
+
+    def _apply_filter(self, qs, params):
+        """Run CollectionVersionSearchFilter against a queryset with the given query params."""
+        request = RequestFactory().get("/", params)
+        request.query_params = request.GET
+        filterset = CollectionVersionSearchFilter(
+            data=request.query_params,
+            queryset=qs,
+            request=request,
+        )
+        return filterset.qs
+
+    def _build_index(self, specs):
+        """Create CVIndex rows from a list of (namespace, name, version) specs."""
+        repo = AnsibleRepository.objects.create(name=randstr())
+        for namespace, name, version in specs:
+            col, _ = Collection.objects.get_or_create(name=name)
+            cv = CollectionVersion.objects.create(
+                collection=col,
+                sha256=randstr(),
+                namespace=namespace,
+                name=name,
+                version=version,
+            )
+            CVIndex.objects.create(
+                repository=repo,
+                collection_version=cv,
+                is_deprecated=False,
+                is_signed=False,
+                is_highest=False,
+            )
+        return CVIndex.objects.all()
+
+    def test_order_by_name_ties_sorted_by_pk(self):
+        """Ensure rows with the same name are sub-sorted by pk descending."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "samename", "1.0.0"),
+                (ns, "samename", "2.0.0"),
+                (ns, "samename", "3.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "name"})
+        pks = list(qs.values_list("pk", flat=True))
+
+        # StableOrderingFilter appends -pk (descending) as tiebreaker
+        assert pks == sorted(pks, reverse=True)
+
+    def test_order_by_name_groups_correctly(self):
+        """Ensure ordering by name groups results alphabetically."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "charlie", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (ns, "bravo", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["alpha", "bravo", "charlie"]
+
+    def test_order_by_name_desc_groups_correctly(self):
+        """Ensure ordering by -name groups results in reverse alphabetical order."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "charlie", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (ns, "bravo", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "-name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["charlie", "bravo", "alpha"]
+
+    def test_order_by_namespace_ties_sorted_by_pk(self):
+        """Ensure rows with the same namespace are sub-sorted by pk descending."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "foo", "1.0.0"),
+                (ns, "bar", "1.0.0"),
+                (ns, "baz", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "namespace"})
+        pks = list(qs.values_list("pk", flat=True))
+
+        # StableOrderingFilter appends -pk (descending) as tiebreaker
+        assert pks == sorted(pks, reverse=True)
+
+    def test_order_by_version_semantic_ordering(self):
+        """Ensure version ordering uses the semver collation correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "col", "2.0.0"),
+                (ns, "col", "1.10.0"),
+                (ns, "col", "1.2.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        # semver collation sorts numerically, not lexicographically
+        assert versions == ["1.2.0", "1.10.0", "2.0.0"]
+
+    def test_order_by_version_desc_semantic_ordering(self):
+        """Ensure descending version ordering uses the semver collation correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "col", "2.0.0"),
+                (ns, "col", "1.10.0"),
+                (ns, "col", "1.2.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"order_by": "-version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        assert versions == ["2.0.0", "1.10.0", "1.2.0"]
+
+    def test_order_by_version_ties_are_stable(self):
+        """Ensure rows with the same version produce stable ordering."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "aaa", "1.0.0"),
+                (ns, "bbb", "1.0.0"),
+                (ns, "ccc", "1.0.0"),
+            ]
+        )
+
+        qs1 = self._apply_filter(qs, {"order_by": "version"})
+        qs2 = self._apply_filter(qs, {"order_by": "version"})
+
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_no_order_by_still_has_stable_ordering(self):
+        """Ensure a default stable ordering is applied even without order_by."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "foo", "1.0.0"),
+                (ns, "bar", "1.0.0"),
+                (ns, "baz", "1.0.0"),
+            ]
+        )
+
+        qs1 = self._apply_filter(qs, {})
+        qs2 = self._apply_filter(qs, {})
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_order_by_name_returns_stable_results(self):
+        """Ensure results ordered by name are stable across repeated evaluations."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "samename", "1.0.0"),
+                (ns, "samename", "2.0.0"),
+                (ns, "samename", "3.0.0"),
+            ]
+        )
+
+        qs1 = self._apply_filter(qs, {"order_by": "name"})
+        qs2 = self._apply_filter(qs, {"order_by": "name"})
+        first_run = list(qs1.values_list("pk", flat=True))
+        second_run = list(qs2.values_list("pk", flat=True))
+
+        assert first_run == second_run
+
+    def test_filter_by_name_with_ordering(self):
+        """Ensure filtering by name combined with ordering works correctly."""
+        ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "target", "1.0.0"),
+                (ns, "target", "2.0.0"),
+                (ns, "other", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"name": "target", "order_by": "version"})
+        versions = list(qs.values_list("collection_version__version", flat=True))
+
+        assert versions == ["1.0.0", "2.0.0"]
+
+    def test_filter_by_namespace_with_ordering(self):
+        """Ensure filtering by namespace combined with ordering works correctly."""
+        ns = randstr()
+        other_ns = randstr()
+        qs = self._build_index(
+            [
+                (ns, "bravo", "1.0.0"),
+                (ns, "alpha", "1.0.0"),
+                (other_ns, "charlie", "1.0.0"),
+            ]
+        )
+
+        qs = self._apply_filter(qs, {"namespace": ns, "order_by": "name"})
+        names = list(qs.values_list("collection_version__name", flat=True))
+
+        assert names == ["alpha", "bravo"]


### PR DESCRIPTION
This is a backport of PR https://github.com/pulp/pulp_ansible/pull/2555 as merged into main (0043923, 0996d68 and ed65302).

Use StableOrderingFilter from pulpcore.plugin.viewsets in SemanticVersionOrderingFilter to append a stable tiebreaker (-pk) for non-version orderings (name, namespace, pulp_created), fixing non-deterministic pagination with tied sort keys.

(cherry picked from commits ed653028, 0996d684, 0043923641fc)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
