### PR TITLE
Add default descending semver ordering to collection version search

### DIFF
--- a/CHANGES/2571.bugfix
+++ b/CHANGES/2571.bugfix
@@ -1,0 +1,1 @@
+Add default descending semver ordering to the collection version search endpoint when no explicit ordering is requested.

--- a/pulp_ansible/app/galaxy/v3/viewsets.py
+++ b/pulp_ansible/app/galaxy/v3/viewsets.py
@@ -85,7 +85,7 @@ class CollectionVersionSearchViewSet(GalaxyAuthMixin, viewsets.ModelViewSet):
             if hasattr(permission_class, "scope_queryset"):
                 qs = permission_class.scope_queryset(self, qs)
 
-        return qs
+        return qs.order_by("-collection_version__version")
 
     def rebuild(self, request, *args, **kwargs):
         async_result = dispatch(


### PR DESCRIPTION
The cross-repo search endpoint (`v3/plugin/ansible/search/collection-versions/`) 
returns versions in arbitrary order when no `order_by` parameter is passed. 
This causes version dropdowns to display 4.7.10 before 4.7.5 (string sorting).

Adds a `filter_queryset` override that applies descending semver ordering 
using the existing `SemanticVersionOrderingFilter` when no explicit ordering 
is requested. Explicit `order_by` and full-text search `?q=` ordering are 
preserved.

Fixes: AAP-78435
Also addresses: AAP-56212

Tested on AAP 2.6-next using aap-dev. Verified:
- Default (no order_by): returns correct descending semver
- Explicit order_by=version: returns correct ascending semver
- Explicit order_by=-version: returns correct descending semver  
- ?q= search: preserves relevance ordering