### PR TITLE
[0.25] Add default descending semver ordering to collection version search

### DIFF
--- a/CHANGES/2571.bugfix
+++ b/CHANGES/2571.bugfix
@@ -1,0 +1,1 @@
+Add default descending semver ordering to the collection version search endpoint when no explicit ordering is requested.

--- a/pulp_ansible/app/galaxy/v3/viewsets.py
+++ b/pulp_ansible/app/galaxy/v3/viewsets.py
@@ -85,7 +85,7 @@ class CollectionVersionSearchViewSet(GalaxyAuthMixin, viewsets.ModelViewSet):
             if hasattr(permission_class, "scope_queryset"):
                 qs = permission_class.scope_queryset(self, qs)
 
-        return qs
+        return qs.order_by("-collection_version__version")
 
     def rebuild(self, request, *args, **kwargs):
         async_result = dispatch(


### PR DESCRIPTION
Backport of #2571 to 0.25.

Fixes: AAP-78435