### PR TITLE
Fix import into a pulp instance that never saw the content

### DIFF
--- a/CHANGES/+export_import_fresh_instance.bugfix
+++ b/CHANGES/+export_import_fresh_instance.bugfix
@@ -1,0 +1,3 @@
+Fixed importing an export into a Pulp instance (or domain) that has never seen the content before.
+Namespace metadata without an avatar failed the digest check, and namespaces, collections and
+deprecations were looked up without regard to the target domain.

--- a/pulp_ansible/app/modelresource.py
+++ b/pulp_ansible/app/modelresource.py
@@ -1,9 +1,10 @@
 import json
 
 from import_export import fields
-from import_export.widgets import Widget
+from import_export.widgets import CharWidget, Widget
 
 from pulpcore.plugin.importexport import BaseContentResource, QueryModelResource
+from pulpcore.plugin.util import get_domain_pk
 
 from pulp_ansible.app.models import (
     AnsibleCollectionDeprecated,
@@ -51,7 +52,7 @@ class AnsibleNamespaceResource(QueryModelResource):
 
     class Meta:
         model = AnsibleNamespace
-        import_id_fields = ("name",)
+        import_id_fields = ("name", "pulp_domain")
 
 
 class DictWidget(Widget):
@@ -72,6 +73,13 @@ class AnsibleNamespaceMetadataResource(BaseContentResource):
     """
 
     links = fields.Field(attribute="links", column_name="links", widget=DictWidget())
+    # allow_blank=False keeps None as None; the default CharWidget would coerce it to ""
+    # and break the metadata_sha256 digest check on import.
+    avatar_sha256 = fields.Field(
+        attribute="avatar_sha256",
+        column_name="avatar_sha256",
+        widget=CharWidget(allow_blank=False),
+    )
 
     def before_import_row(self, row, **kwargs):
         """
@@ -79,7 +87,7 @@ class AnsibleNamespaceMetadataResource(BaseContentResource):
         """
         super().before_import_row(row, **kwargs)
 
-        namespace = AnsibleNamespace.objects.get(name=row["name"])
+        namespace = AnsibleNamespace.objects.get(name=row["name"], pulp_domain=get_domain_pk())
         row["namespace"] = str(namespace.pk)
         if row["avatar_sha256"] == "":
             row["avatar_sha256"] = None
@@ -110,7 +118,9 @@ class CollectionVersionContentResource(BaseContentResource):
         """
         super().before_import_row(row, **kwargs)
 
-        col = Collection.objects.get(name=row["name"], namespace=row["namespace"])
+        col = Collection.objects.get(
+            name=row["name"], namespace=row["namespace"], pulp_domain=get_domain_pk()
+        )
         row["collection"] = str(col.pk)
         row.pop("is_highest", None)
 
@@ -146,7 +156,9 @@ class CollectionVersionSignatureResource(BaseContentResource):
         """
         super().before_import_row(row, **kwargs)
 
-        cv = CollectionVersion.objects.get(upstream_id=row["signed_collection"])
+        cv = CollectionVersion.objects.get(
+            upstream_id=row["signed_collection"], _pulp_domain=get_domain_pk()
+        )
         row["signed_collection"] = str(cv.pk)
 
     class Meta:
@@ -176,7 +188,9 @@ class CollectionVersionMarkResource(BaseContentResource):
         """
         super().before_import_row(row, **kwargs)
 
-        cv = CollectionVersion.objects.get(upstream_id=row["marked_collection"])
+        cv = CollectionVersion.objects.get(
+            upstream_id=row["marked_collection"], _pulp_domain=get_domain_pk()
+        )
         row["marked_collection"] = str(cv.pk)
 
     class Meta:
@@ -200,7 +214,7 @@ class CollectionResource(QueryModelResource):
 
     class Meta:
         model = Collection
-        import_id_fields = ("namespace", "name")
+        import_id_fields = ("namespace", "name", "pulp_domain")
 
 
 class CollectionDeprecationResource(BaseContentResource):
@@ -216,7 +230,7 @@ class CollectionDeprecationResource(BaseContentResource):
 
     class Meta:
         model = AnsibleCollectionDeprecated
-        import_id_fields = ("namespace", "name")
+        import_id_fields = model.natural_key_fields()
 
 
 IMPORT_ORDER = [

--- a/pulp_ansible/tests/functional/api/test_export_import.py
+++ b/pulp_ansible/tests/functional/api/test_export_import.py
@@ -207,3 +207,87 @@ def test_export_then_import(
         repo = ansible_bindings.RepositoriesAnsibleApi.read(repo.pulp_href)
         # still only one version as pulp won't create a new version if nothing changed
         assert repo.latest_version_href == f"{repo.pulp_href}versions/1/"
+
+
+def test_export_then_import_into_new_domain(
+    pulpcore_bindings,
+    ansible_bindings,
+    gen_object_with_cleanup,
+    ansible_repo_factory,
+    build_and_upload_collection,
+    ansible_distribution_factory,
+    ascii_armored_detached_signing_service,
+    domain_factory,
+    monitor_task,
+    monitor_task_group,
+):
+    """Import an export into a fresh domain - equivalent to a second, empty pulp instance."""
+    repo = ansible_repo_factory()
+    distro = ansible_distribution_factory(repository=repo)
+    collection, _ = build_and_upload_collection(repo)
+
+    signing_body = {
+        "signing_service": ascii_armored_detached_signing_service.pulp_href,
+        "content_units": ["*"],
+    }
+    monitor_task(ansible_bindings.RepositoriesAnsibleApi.sign(repo.pulp_href, signing_body).task)
+    mark_body = {"content_units": ["*"], "value": "exportable-mark"}
+    monitor_task(ansible_bindings.RepositoriesAnsibleApi.mark(repo.pulp_href, mark_body).task)
+    monitor_task(
+        ansible_bindings.ContentCollectionDeprecationsApi.create(
+            {
+                "namespace": collection.namespace,
+                "name": collection.name,
+                "repository": repo.pulp_href,
+            }
+        ).task
+    )
+    # A namespace without an avatar - nullable fields must survive the export/import round-trip.
+    monitor_task(
+        ansible_bindings.PulpAnsibleApiV3PluginAnsibleContentNamespacesApi.create(
+            path=distro.base_path,
+            distro_base_path=distro.base_path,
+            name=collection.namespace,
+            company="Export Test Corp",
+        ).task
+    )
+
+    repo = ansible_bindings.RepositoriesAnsibleApi.read(repo.pulp_href)
+    source_version = ansible_bindings.RepositoriesAnsibleVersionsApi.read(repo.latest_version_href)
+
+    exporter = gen_object_with_cleanup(
+        pulpcore_bindings.ExportersPulpApi,
+        {
+            "name": str(uuid.uuid4()),
+            "path": f"/tmp/{uuid.uuid4()}/",
+            "repositories": [repo.pulp_href],
+        },
+    )
+    task = monitor_task(
+        pulpcore_bindings.ExportersPulpExportsApi.create(exporter.pulp_href, {}).task
+    )
+    export = pulpcore_bindings.ExportersPulpExportsApi.read(task.created_resources[0])
+    export_filename = next(
+        f for f in export.output_file_info.keys() if f.endswith(("tar.gz", "tar"))
+    )
+
+    # The fresh domain has no content at all, just like a second pulp instance.
+    domain = domain_factory()
+    dest_repo = ansible_repo_factory(pulp_domain=domain.name)
+    importer = gen_object_with_cleanup(
+        pulpcore_bindings.ImportersPulpApi,
+        {"name": str(uuid.uuid4()), "repo_mapping": {repo.name: dest_repo.name}},
+        pulp_domain=domain.name,
+    )
+    import_response = pulpcore_bindings.ImportersPulpImportsApi.create(
+        importer.pulp_href, {"path": export_filename}
+    )
+    monitor_task_group(import_response.task_group)
+
+    dest_repo = ansible_bindings.RepositoriesAnsibleApi.read(dest_repo.pulp_href)
+    assert dest_repo.latest_version_href == f"{dest_repo.pulp_href}versions/1/"
+    imported_version = ansible_bindings.RepositoriesAnsibleVersionsApi.read(
+        dest_repo.latest_version_href
+    )
+    for content_type, summary in source_version.content_summary.present.items():
+        assert imported_version.content_summary.added[content_type]["count"] == summary["count"]


### PR DESCRIPTION
Importing an export into an empty target (a second instance or a fresh domain) failed and could corrupt other domains:

- avatar_sha256=None was coerced to "" by the default CharWidget on import, tripping the metadata_sha256 digest check and failing the whole import. Declare the field with CharWidget(allow_blank=False).
- Namespace, collection and deprecation rows were matched and looked up without regard to the target domain, hijacking rows from other domains. Scope import_id_fields and before_import_row lookups with the current domain.

Adds a functional test importing an export into a freshly created domain, which is equivalent to a second, empty pulp instance.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
